### PR TITLE
Fix mobile remote connection to support tunnel URLs

### DIFF
--- a/docs/remote/index.html
+++ b/docs/remote/index.html
@@ -25,27 +25,27 @@
 
       <div class="connect-form">
         <div class="input-group">
-          <label for="ip-input">Desktop IP address</label>
+          <label for="ip-input">IP address or tunnel URL</label>
           <input
             type="text"
             id="ip-input"
-            placeholder="192.168.1.x"
-            inputmode="text"
+            placeholder="192.168.1.x or xxx.tunnelto.dev"
+            inputmode="url"
             autocomplete="off"
           >
         </div>
 
         <div class="input-group">
-          <label for="code-input">Pairing code</label>
+          <label for="code-input">Pairing code or password</label>
           <input
             type="text"
             id="code-input"
             placeholder="A3F7X2"
-            maxlength="6"
+            maxlength="32"
             inputmode="text"
             autocapitalize="characters"
             autocomplete="off"
-            style="text-transform: uppercase; letter-spacing: 0.3em; text-align: center; font-size: 1.5rem;"
+            style="text-transform: uppercase; letter-spacing: 0.2em; text-align: center; font-size: 1.25rem;"
           >
         </div>
 
@@ -58,7 +58,7 @@
       </div>
 
       <div class="connect-help">
-        <p>Find the pairing code in AudioBash Settings on your desktop</p>
+        <p>Find connection details in AudioBash Settings &gt; Remote Control</p>
       </div>
     </div>
 


### PR DESCRIPTION
The mobile WebSocket manager was rejecting tunnel URLs like subdomain.tunnelto.dev because it only accepted IP addresses.

Changes:
- Update websocket.js to accept IP addresses, hostnames, and full URLs
- Auto-detect tunnel URLs vs IP addresses for proper port handling
- Update app.js to pass correct port (null for tunnels, 8766 for IPs)
- Update HTML labels and placeholders for clarity
- Increase maxlength on code input for static passwords
- Add better error messages for connection issues

---

COPILOT SUMMARY:

This pull request updates the AudioBash Remote Control web interface to support connecting via both local IP addresses and remote tunnel URLs, improving usability for users connecting from outside their local network. It also refines the UI and error messages for clarity and flexibility.

**Connection input and logic improvements:**

* The "IP address" input field now accepts both IP addresses and tunnel URLs, with updated placeholder and input mode for better user guidance. The connection logic detects whether the input is an IP or tunnel URL and constructs the appropriate WebSocket URL, supporting direct wss://, ws://, http(s)://, and tunnelto.dev addresses. (`docs/remote/index.html`, `docs/remote/js/app.js`, `docs/remote/js/websocket.js`) [[1]](diffhunk://#diff-b65b9344a5aebb1abfcc0caa7e31e1c69241bbf0499d3c255cd6d8f0926039c6L28-R48) [[2]](diffhunk://#diff-86edff546191ff00ce835dafabf2bdf40ed3eeee6789e8c500868b96c0da2773L205-R210) [[3]](diffhunk://#diff-86edff546191ff00ce835dafabf2bdf40ed3eeee6789e8c500868b96c0da2773L228-R239) [[4]](diffhunk://#diff-53873b2fcfa35a85447adf4c4b3052437bee1298bfa34df0addb72ca78eb3f1dL34-R76)

* The pairing code input now supports up to 32 characters and is relabeled to allow for passwords as well as codes, making it compatible with more secure connection options. (`docs/remote/index.html`)

**User interface and help text updates:**

* Labels and help texts have been updated for clarity, reflecting the new connection options and guiding users to the correct settings location in AudioBash. (`docs/remote/index.html`)

**Error handling improvements:**

* Error messages are now more descriptive, including a new message for connection refusal and revised instructions for invalid codes and already-connected devices, referencing the correct AudioBash settings section. (`docs/remote/js/websocket.js`)