### PR TITLE
Create themed SVG favicon for GitHub

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Development notes, testing strategies, and behind-the-scenes from the AudioBash project.">
     <meta property="og:type" content="website">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/blog/end-user-testing.html
+++ b/docs/blog/end-user-testing.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="A practical guide to end-user testing with Claude Code. Stress-test your apps like non-technical users.">
     <meta property="og:type" content="article">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#050505"/>
+  <!-- Terminal prompt bracket -->
+  <path d="M6 8 L12 16 L6 24" stroke="#ccff00" stroke-width="3" stroke-linecap="square" fill="none"/>
+  <!-- Audio waves -->
+  <rect x="16" y="13" width="2" height="6" fill="#ccff00"/>
+  <rect x="20" y="10" width="2" height="12" fill="#ccff00"/>
+  <rect x="24" y="7" width="2" height="18" fill="#ccff00"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Speak commands, execute instantly. Multi-tab terminal with AI-powered voice transcription. Available for Windows and macOS.">
     <meta property="og:type" content="website">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -17,6 +17,9 @@
     <meta name="twitter:title" content="AudioBash for macOS - Now Available">
     <meta name="twitter:description" content="Voice-controlled terminal for developers. Native Apple Silicon and Intel Mac support.">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Complete guide to installing and using AudioBash on Windows and macOS.">
     <meta property="og:type" content="website">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Release history and changelog for AudioBash - Voice-controlled terminal for developers.">
     <meta property="og:type" content="website">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/remote/index.html
+++ b/docs/remote/index.html
@@ -7,6 +7,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.json">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.css">
   <link rel="stylesheet" href="css/styles.css">
   <title>AudioBash Remote</title>


### PR DESCRIPTION
This pull request adds a favicon to all main documentation and blog HTML pages for the AudioBash project, ensuring consistent branding and a more polished appearance across the site.

**Site appearance and branding:**
* Added a favicon (`favicon.svg`) link to the `<head>` of the following pages: `docs/blog.html`, `docs/manual.html`, `docs/index.html`, `docs/macos.html`, and `docs/releases.html` [[1]](diffhunk://#diff-d942fb0f480cd99693643efabea269633c8a55a129b646e09865c3e4628fb734R14-R16) [[2]](diffhunk://#diff-0c4bd45e81decde9e37a61d34c56fdf26e803bb7e045d1d24a37e1f19ccd9593R14-R16) [[3]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR14-R16) [[4]](diffhunk://#diff-4debd281ce5b9c885037910089502666f126a0277f985975b72d38f492895b70R20-R22) [[5]](diffhunk://#diff-092182d397ba5a75398bc7ff5905eddec0a84b7ec65d7a36c943d73820a7499fR14-R16)
* Added a favicon link (with the correct relative path) to `docs/blog/end-user-testing.html` and `docs/remote/index.html` [[1]](diffhunk://#diff-ad1b3697b81531028b2b1f83fafdb64299ba1a955197b8d41726b95528e31652R14-R16) [[2]](diffhunk://#diff-b65b9344a5aebb1abfcc0caa7e31e1c69241bbf0499d3c255cd6d8f0926039c6R10)