### PR TITLE
Update GitHub page to red theme

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -33,8 +33,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -52,14 +52,14 @@
         }
 
         ::selection {
-            background-color: #ccff00;
+            background-color: #ff3333;
             color: #000;
         }
 
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: #050505; }
         ::-webkit-scrollbar-thumb { background: #333; }
-        ::-webkit-scrollbar-thumb:hover { background: #ccff00; }
+        ::-webkit-scrollbar-thumb:hover { background: #ff3333; }
 
         .clip-notch {
             clip-path: polygon(
@@ -88,11 +88,11 @@
             transition: all 0.2s ease;
         }
         .post-card:hover {
-            border-color: rgba(204, 255, 0, 0.5);
+            border-color: rgba(255, 51, 51, 0.5);
             transform: translateY(-2px);
         }
         .post-card:hover .post-title {
-            color: #ccff00;
+            color: #ff3333;
         }
     </style>
 </head>
@@ -108,7 +108,7 @@
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
                 <a href="index.html" class="flex items-center gap-3">
-                    <div class="w-10 h-10 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
+                    <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
                         <p class="text-[9px] text-gray-500 tracking-[0.2em]">v2.0.2 // VOICE_TERMINAL</p>
@@ -118,7 +118,7 @@
             <div class="flex items-center gap-4">
                 <a href="manual.html" class="text-gray-400 hover:text-chrome transition-colors text-sm font-display hidden sm:block">MANUAL</a>
                 <a href="releases.html" class="text-gray-400 hover:text-chrome transition-colors text-sm font-display hidden sm:block">RELEASES</a>
-                <a href="blog.html" class="text-acid hover:text-acid/80 transition-colors text-sm font-display hidden sm:block">BLOG</a>
+                <a href="blog.html" class="text-accent hover:text-accent/80 transition-colors text-sm font-display hidden sm:block">BLOG</a>
                 <a href="https://github.com/jamditis/audiobash" class="text-gray-400 hover:text-chrome transition-colors">
                     <i data-lucide="github" class="w-5 h-5"></i>
                 </a>
@@ -132,7 +132,7 @@
             <!-- Page Header -->
             <header class="mb-12">
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">TRANSMISSION_LOG</h1>
-                <p class="text-gray-400 text-lg border-l-2 border-acid pl-4">
+                <p class="text-gray-400 text-lg border-l-2 border-accent pl-4">
                     Notes on building AudioBash.
                 </p>
             </header>
@@ -145,7 +145,7 @@
                     <div class="flex items-start justify-between gap-4">
                         <div class="flex-1">
                             <div class="flex items-center gap-3 text-xs text-gray-500 mb-3">
-                                <span class="px-2 py-1 bg-acid/10 border border-acid/30 text-acid">TESTING</span>
+                                <span class="px-2 py-1 bg-accent/10 border border-accent/30 text-accent">TESTING</span>
                                 <span>January 2, 2026</span>
                                 <span class="flex items-center gap-1">
                                     <i data-lucide="clock" class="w-3 h-3"></i>
@@ -155,7 +155,7 @@
                             <h2 class="post-title font-display text-xl text-chrome mb-2 transition-colors">How I learned to break my own app</h2>
                             <p class="text-gray-400 text-sm">Stress-testing apps the way non-technical users do: double-clicks, giant pastes, window resizing to 100x100 pixels.</p>
                         </div>
-                        <div class="text-gray-500 group-hover:text-acid transition-colors">
+                        <div class="text-gray-500 group-hover:text-accent transition-colors">
                             <i data-lucide="arrow-right" class="w-5 h-5"></i>
                         </div>
                     </div>
@@ -175,7 +175,7 @@
             <div class="mt-16 bg-panel border border-white/10 p-8 text-center">
                 <h3 class="font-display text-xl text-chrome mb-2">Stay Updated</h3>
                 <p class="text-gray-400 text-sm mb-6">Star the repo to follow development progress.</p>
-                <a href="https://github.com/jamditis/audiobash" class="inline-flex items-center gap-2 px-6 py-3 bg-acid text-black font-display font-bold tracking-wider hover:bg-acid/80 transition-all clip-notch">
+                <a href="https://github.com/jamditis/audiobash" class="inline-flex items-center gap-2 px-6 py-3 bg-accent text-black font-display font-bold tracking-wider hover:bg-accent/80 transition-all clip-notch">
                     <i data-lucide="star" class="w-4 h-4"></i>
                     STAR ON GITHUB
                 </a>
@@ -191,10 +191,10 @@
                 AUDIOBASH v2.0.2 // BLOG // MIT LICENSE
             </div>
             <div class="flex items-center gap-4 text-gray-500">
-                <a href="https://github.com/jamditis/audiobash" class="hover:text-acid transition-colors">
+                <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">
                     <i data-lucide="github" class="w-4 h-4"></i>
                 </a>
-                <a href="https://github.com/jamditis" class="hover:text-acid transition-colors text-xs font-mono">
+                <a href="https://github.com/jamditis" class="hover:text-accent transition-colors text-xs font-mono">
                     @jamditis
                 </a>
             </div>

--- a/docs/blog/end-user-testing.html
+++ b/docs/blog/end-user-testing.html
@@ -33,8 +33,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -52,14 +52,14 @@
         }
 
         ::selection {
-            background-color: #ccff00;
+            background-color: #ff3333;
             color: #000;
         }
 
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: #050505; }
         ::-webkit-scrollbar-thumb { background: #333; }
-        ::-webkit-scrollbar-thumb:hover { background: #ccff00; }
+        ::-webkit-scrollbar-thumb:hover { background: #ff3333; }
 
         .clip-notch {
             clip-path: polygon(
@@ -95,11 +95,11 @@
             font-weight: 600;
             margin-top: 3rem;
             margin-bottom: 1rem;
-            border-left: 3px solid #ccff00;
+            border-left: 3px solid #ff3333;
             padding-left: 1rem;
         }
         .prose-void h3 {
-            color: #ccff00;
+            color: #ff3333;
             font-family: 'Share Tech Mono', monospace;
             font-size: 1.1rem;
             margin-top: 2rem;
@@ -114,14 +114,14 @@
             text-underline-offset: 3px;
         }
         .prose-void a:hover {
-            color: #ccff00;
+            color: #ff3333;
         }
         .prose-void code {
             background: #111;
             padding: 0.2rem 0.4rem;
             border-radius: 2px;
             font-size: 0.9em;
-            color: #ccff00;
+            color: #ff3333;
         }
         .prose-void pre {
             background: #0a0a0a;
@@ -154,8 +154,8 @@
         }
 
         .insight-box {
-            background: linear-gradient(135deg, rgba(204, 255, 0, 0.05), rgba(0, 240, 255, 0.05));
-            border: 1px solid rgba(204, 255, 0, 0.2);
+            background: linear-gradient(135deg, rgba(255, 51, 51, 0.05), rgba(0, 240, 255, 0.05));
+            border: 1px solid rgba(255, 51, 51, 0.2);
             padding: 1.5rem;
             margin: 2rem 0;
         }
@@ -164,7 +164,7 @@
             display: block;
             font-family: 'Share Tech Mono', monospace;
             font-size: 0.75rem;
-            color: #ccff00;
+            color: #ff3333;
             margin-bottom: 0.75rem;
             letter-spacing: 0.1em;
         }
@@ -182,7 +182,7 @@
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
                 <a href="../index.html" class="flex items-center gap-3">
-                    <div class="w-10 h-10 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
+                    <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
                         <p class="text-[9px] text-gray-500 tracking-[0.2em]">BLOG</p>
@@ -192,7 +192,7 @@
             <div class="flex items-center gap-4">
                 <a href="../manual.html" class="text-gray-400 hover:text-chrome transition-colors text-sm font-display hidden sm:block">MANUAL</a>
                 <a href="../releases.html" class="text-gray-400 hover:text-chrome transition-colors text-sm font-display hidden sm:block">RELEASES</a>
-                <a href="../blog.html" class="text-acid hover:text-acid/80 transition-colors text-sm font-display hidden sm:block">BLOG</a>
+                <a href="../blog.html" class="text-accent hover:text-accent/80 transition-colors text-sm font-display hidden sm:block">BLOG</a>
                 <a href="https://github.com/jamditis/audiobash" class="text-gray-400 hover:text-chrome transition-colors">
                     <i data-lucide="github" class="w-5 h-5"></i>
                 </a>
@@ -206,7 +206,7 @@
             <!-- Article Header -->
             <header class="mb-12">
                 <div class="flex items-center gap-3 text-sm text-gray-500 mb-4">
-                    <a href="../blog.html" class="hover:text-acid transition-colors flex items-center gap-1">
+                    <a href="../blog.html" class="hover:text-accent transition-colors flex items-center gap-1">
                         <i data-lucide="arrow-left" class="w-4 h-4"></i>
                         BLOG
                     </a>
@@ -214,12 +214,12 @@
                     <span>January 2, 2026</span>
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-6">How I learned to break my own app</h1>
-                <p class="text-xl text-gray-400 border-l-2 border-acid pl-4">Testing apps like your least technical family member would</p>
+                <p class="text-xl text-gray-400 border-l-2 border-accent pl-4">Testing apps like your least technical family member would</p>
 
                 <div class="flex items-center gap-4 mt-6 pt-6 border-t border-white/10">
                     <div class="flex items-center gap-2">
-                        <div class="w-8 h-8 bg-acid/20 rounded-full flex items-center justify-center">
-                            <i data-lucide="user" class="w-4 h-4 text-acid"></i>
+                        <div class="w-8 h-8 bg-accent/20 rounded-full flex items-center justify-center">
+                            <i data-lucide="user" class="w-4 h-4 text-accent"></i>
                         </div>
                         <span class="text-sm text-gray-400">@jamditis</span>
                     </div>
@@ -407,7 +407,7 @@ echo "Failed: $FAILED"</code></pre>
             <!-- Article Footer -->
             <footer class="mt-16 pt-8 border-t border-white/10">
                 <div class="flex items-center justify-between">
-                    <a href="../blog.html" class="flex items-center gap-2 text-gray-400 hover:text-acid transition-colors">
+                    <a href="../blog.html" class="flex items-center gap-2 text-gray-400 hover:text-accent transition-colors">
                         <i data-lucide="arrow-left" class="w-4 h-4"></i>
                         <span>Back to Blog</span>
                     </a>
@@ -429,10 +429,10 @@ echo "Failed: $FAILED"</code></pre>
                 AUDIOBASH v2.0.2 // BLOG // MIT LICENSE
             </div>
             <div class="flex items-center gap-4 text-gray-500">
-                <a href="https://github.com/jamditis/audiobash" class="hover:text-acid transition-colors">
+                <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">
                     <i data-lucide="github" class="w-4 h-4"></i>
                 </a>
-                <a href="https://github.com/jamditis" class="hover:text-acid transition-colors text-xs font-mono">
+                <a href="https://github.com/jamditis" class="hover:text-accent transition-colors text-xs font-mono">
                     @jamditis
                 </a>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,8 +33,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -56,8 +56,8 @@
                             '50%': { transform: 'translateY(-10px)' },
                         },
                         glow: {
-                            '0%': { boxShadow: '0 0 20px rgba(204, 255, 0, 0.3)' },
-                            '100%': { boxShadow: '0 0 40px rgba(204, 255, 0, 0.6)' },
+                            '0%': { boxShadow: '0 0 20px rgba(255, 51, 51, 0.3)' },
+                            '100%': { boxShadow: '0 0 40px rgba(255, 51, 51, 0.6)' },
                         }
                     }
                 }
@@ -72,14 +72,14 @@
         }
 
         ::selection {
-            background-color: #ccff00;
+            background-color: #ff3333;
             color: #000;
         }
 
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: #050505; }
         ::-webkit-scrollbar-thumb { background: #333; }
-        ::-webkit-scrollbar-thumb:hover { background: #ccff00; }
+        ::-webkit-scrollbar-thumb:hover { background: #ff3333; }
 
         .clip-notch {
             clip-path: polygon(
@@ -128,13 +128,13 @@
         }
         .glitch-text::before {
             left: 2px;
-            text-shadow: -1px 0 #ccff00;
+            text-shadow: -1px 0 #ff3333;
             clip: rect(44px, 450px, 56px, 0);
             animation: glitch-anim 5s infinite linear alternate-reverse;
         }
         .glitch-text::after {
             left: -2px;
-            text-shadow: -1px 0 #ff2a2a;
+            text-shadow: -1px 0 #00f0ff;
             clip: rect(44px, 450px, 56px, 0);
             animation: glitch-anim2 5s infinite linear alternate-reverse;
         }
@@ -164,7 +164,7 @@
         }
         .waveform span {
             width: 4px;
-            background: linear-gradient(to top, #ccff00, #00f0ff);
+            background: linear-gradient(to top, #ff3333, #ff6666);
             border-radius: 2px;
             animation: wave 1s ease-in-out infinite;
         }
@@ -193,7 +193,7 @@
     <nav class="fixed top-0 left-0 right-0 z-50 bg-void/80 backdrop-blur-sm border-b border-white/10">
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
-                <div class="w-10 h-10 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
+                <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                 <div>
                     <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
                     <p class="text-[9px] text-gray-500 tracking-[0.2em]">v2.0.2 // VOICE_TERMINAL</p>
@@ -206,7 +206,7 @@
                 <a href="https://github.com/jamditis/audiobash" class="text-gray-400 hover:text-chrome transition-colors">
                     <i data-lucide="github" class="w-5 h-5"></i>
                 </a>
-                <a href="#download" class="px-4 py-2 bg-acid text-black font-display font-bold text-sm tracking-wider hover:bg-acid/80 transition-colors clip-notch">
+                <a href="#download" class="px-4 py-2 bg-accent text-black font-display font-bold text-sm tracking-wider hover:bg-accent/80 transition-colors clip-notch">
                     DOWNLOAD
                 </a>
             </div>
@@ -225,21 +225,21 @@
                 </div>
 
                 <!-- NEW: v2.0 Badge -->
-                <a href="macos.html" class="inline-flex items-center gap-2 px-4 py-2 bg-acid/10 border border-acid/30 text-acid text-sm font-mono mb-6 hover:bg-acid/20 transition-colors">
-                    <span class="w-2 h-2 bg-acid rounded-full animate-pulse"></span>
+                <a href="macos.html" class="inline-flex items-center gap-2 px-4 py-2 bg-accent/10 border border-accent/30 text-accent text-sm font-mono mb-6 hover:bg-accent/20 transition-colors">
+                    <span class="w-2 h-2 bg-accent rounded-full animate-pulse"></span>
                     v2.0.2 — NOW ON macOS
                     <i data-lucide="arrow-right" class="w-4 h-4"></i>
                 </a>
 
                 <h2 class="font-display text-5xl md:text-7xl text-chrome mb-6 glitch-text" data-text="SPEAK_EXECUTE">SPEAK_EXECUTE</h2>
 
-                <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8 border-l-2 border-acid pl-4 text-left">
+                <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8 border-l-2 border-accent pl-4 text-left">
                     Voice-controlled terminal for developers. Speak your commands naturally, watch them execute instantly. Multi-tab terminals, multiple AI providers, fully customizable.
                 </p>
 
                 <!-- Platform Download Buttons -->
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-6">
-                    <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash.Setup.2.0.2.exe" class="px-8 py-4 bg-acid text-black font-display font-bold text-lg tracking-wider hover:bg-acid/80 transition-all clip-notch animate-glow">
+                    <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash.Setup.2.0.2.exe" class="px-8 py-4 bg-accent text-black font-display font-bold text-lg tracking-wider hover:bg-accent/80 transition-all clip-notch animate-glow">
                         <span class="flex items-center gap-2">
                             <i data-lucide="monitor" class="w-5 h-5"></i>
                             WINDOWS
@@ -259,7 +259,7 @@
                             macOS (Intel)
                         </span>
                     </a>
-                    <a href="https://github.com/jamditis/audiobash" class="px-6 py-3 border border-white/20 text-chrome font-display font-bold text-sm tracking-wider hover:border-acid hover:text-acid transition-all">
+                    <a href="https://github.com/jamditis/audiobash" class="px-6 py-3 border border-white/20 text-chrome font-display font-bold text-sm tracking-wider hover:border-accent hover:text-accent transition-all">
                         <span class="flex items-center gap-2">
                             <i data-lucide="github" class="w-4 h-4"></i>
                             VIEW SOURCE
@@ -273,10 +273,10 @@
                         <div class="flex gap-2">
                             <div class="w-3 h-3 rounded-full bg-signal/50"></div>
                             <div class="w-3 h-3 rounded-full bg-yellow-500/50"></div>
-                            <div class="w-3 h-3 rounded-full bg-acid/50"></div>
+                            <div class="w-3 h-3 rounded-full bg-accent/50"></div>
                         </div>
                         <div class="flex gap-1">
-                            <span class="px-3 py-1 bg-void text-acid text-xs border-t border-l border-r border-white/20">zsh</span>
+                            <span class="px-3 py-1 bg-void text-accent text-xs border-t border-l border-r border-white/20">zsh</span>
                             <span class="px-3 py-1 text-gray-500 text-xs">Terminal 2</span>
                             <span class="px-3 py-1 text-gray-500 text-xs">+</span>
                         </div>
@@ -288,7 +288,7 @@
                             <span class="text-ice">[VOICE]</span>
                             <span class="text-chrome">"list all files in this directory"</span>
                         </div>
-                        <div class="text-acid mb-2">→ ls -la</div>
+                        <div class="text-accent mb-2">→ ls -la</div>
                         <div class="text-gray-400 text-xs">
                             <div>drwxr-xr-x   8 user  staff   256 Jan  2 10:00 src</div>
                             <div>drwxr-xr-x  42 user  staff  1344 Jan  2 09:45 node_modules</div>
@@ -298,7 +298,7 @@
                     </div>
                     <div class="bg-surface border-t border-white/10 px-4 py-2 flex items-center justify-between text-[10px] text-gray-500">
                         <div class="flex items-center gap-2">
-                            <span class="w-2 h-2 bg-acid rounded-full animate-pulse"></span>
+                            <span class="w-2 h-2 bg-accent rounded-full animate-pulse"></span>
                             <span>READY</span>
                         </div>
                         <div>Gemini 2.0 Flash</div>
@@ -309,10 +309,10 @@
         </section>
 
         <!-- WHAT'S NEW IN v2.0 -->
-        <section class="py-16 px-6 bg-acid/5 border-y border-acid/20">
+        <section class="py-16 px-6 bg-accent/5 border-y border-accent/20">
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-8">
-                    <h3 class="font-display text-2xl text-acid mb-2">NEW IN v2.0.0</h3>
+                    <h3 class="font-display text-2xl text-accent mb-2">NEW IN v2.0.0</h3>
                     <p class="text-gray-500 font-mono">The macOS Edition</p>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
@@ -347,9 +347,9 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                     <!-- Feature 1 -->
-                    <div class="bg-panel border border-white/10 p-6 hover:border-acid/50 transition-colors group">
-                        <div class="w-12 h-12 bg-acidDim border border-acid/30 flex items-center justify-center mb-4 clip-notch-tl">
-                            <i data-lucide="mic" class="w-6 h-6 text-acid"></i>
+                    <div class="bg-panel border border-white/10 p-6 hover:border-accent/50 transition-colors group">
+                        <div class="w-12 h-12 bg-accentDim border border-accent/30 flex items-center justify-center mb-4 clip-notch-tl">
+                            <i data-lucide="mic" class="w-6 h-6 text-accent"></i>
                         </div>
                         <h4 class="font-display text-lg text-chrome mb-2">VOICE_RECOGNITION</h4>
                         <p class="text-gray-500 text-sm">Multiple AI providers: Gemini, OpenAI Whisper, Claude, ElevenLabs. Choose your engine.</p>
@@ -374,9 +374,9 @@
                     </div>
 
                     <!-- Feature 4 -->
-                    <div class="bg-panel border border-white/10 p-6 hover:border-acid/50 transition-colors group">
-                        <div class="w-12 h-12 bg-acidDim border border-acid/30 flex items-center justify-center mb-4 clip-notch-tl">
-                            <i data-lucide="brain" class="w-6 h-6 text-acid"></i>
+                    <div class="bg-panel border border-white/10 p-6 hover:border-accent/50 transition-colors group">
+                        <div class="w-12 h-12 bg-accentDim border border-accent/30 flex items-center justify-center mb-4 clip-notch-tl">
+                            <i data-lucide="brain" class="w-6 h-6 text-accent"></i>
                         </div>
                         <h4 class="font-display text-lg text-chrome mb-2">CONTEXT_AWARE</h4>
                         <p class="text-gray-500 text-sm">Agent mode understands your environment: current directory, recent output, errors. Smarter commands.</p>
@@ -416,7 +416,7 @@
                 <div class="space-y-8">
 
                     <div class="flex items-start gap-6">
-                        <div class="w-16 h-16 bg-acid text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">01</div>
+                        <div class="w-16 h-16 bg-accent text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">01</div>
                         <div>
                             <h4 class="font-display text-xl text-chrome mb-2">ACTIVATE</h4>
                             <p class="text-gray-400 font-mono">Press your configured hotkey (Alt+S on Windows, Option+S on Mac) to start voice capture. The floating overlay appears.</p>
@@ -447,8 +447,8 @@
         <section id="download" class="py-32 px-6">
             <div class="max-w-4xl mx-auto text-center">
 
-                <div class="bg-panel border border-acid/30 p-12 relative overflow-hidden">
-                    <div class="absolute top-0 right-0 w-64 h-64 bg-acid/5 blur-3xl"></div>
+                <div class="bg-panel border border-accent/30 p-12 relative overflow-hidden">
+                    <div class="absolute top-0 right-0 w-64 h-64 bg-accent/5 blur-3xl"></div>
 
                     <h3 class="font-display text-4xl text-chrome mb-4 relative">INITIALIZE_NOW</h3>
                     <p class="text-gray-400 font-mono mb-8 relative">Free and open source. Windows + macOS ready.</p>
@@ -489,13 +489,13 @@
                     </div>
 
                     <div class="flex items-center justify-center gap-4 relative">
-                        <a href="https://github.com/jamditis/audiobash" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-acid hover:text-acid transition-all">
+                        <a href="https://github.com/jamditis/audiobash" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-accent hover:text-accent transition-all">
                             <span class="flex items-center gap-2">
                                 <i data-lucide="star" class="w-5 h-5"></i>
                                 STAR ON GITHUB
                             </span>
                         </a>
-                        <a href="https://github.com/jamditis/audiobash/blob/master/docs/USER_MANUAL.md" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-acid hover:text-acid transition-all">
+                        <a href="https://github.com/jamditis/audiobash/blob/master/docs/USER_MANUAL.md" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-accent hover:text-accent transition-all">
                             <span class="flex items-center gap-2">
                                 <i data-lucide="book-open" class="w-5 h-5"></i>
                                 USER MANUAL
@@ -546,10 +546,10 @@
                     AUDIOBASH v2.0.2 // BUILD 2026.01.02 // MIT LICENSE
                 </div>
                 <div class="flex items-center gap-4 text-gray-500">
-                    <a href="https://github.com/jamditis/audiobash" class="hover:text-acid transition-colors">
+                    <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">
                         <i data-lucide="github" class="w-4 h-4"></i>
                     </a>
-                    <a href="https://github.com/jamditis" class="hover:text-acid transition-colors text-xs font-mono">
+                    <a href="https://github.com/jamditis" class="hover:text-accent transition-colors text-xs font-mono">
                         @jamditis
                     </a>
                 </div>

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -39,8 +39,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -365,11 +365,11 @@
 
                     <!-- Step 5 -->
                     <div class="flex gap-4">
-                        <div class="w-10 h-10 bg-acid text-black font-display font-bold flex items-center justify-center shrink-0">5</div>
+                        <div class="w-10 h-10 bg-accent text-black font-display font-bold flex items-center justify-center shrink-0">5</div>
                         <div>
                             <h4 class="font-display text-chrome text-lg mb-2">Add your API key</h4>
                             <p class="text-gray-400 text-sm mb-3">Click the gear icon and enter your transcription API key. We recommend Gemini (free tier available):</p>
-                            <a href="https://aistudio.google.com/app/apikey" class="inline-flex items-center gap-2 text-acid hover:underline text-sm">
+                            <a href="https://aistudio.google.com/app/apikey" class="inline-flex items-center gap-2 text-accent hover:underline text-sm">
                                 <i data-lucide="external-link" class="w-4 h-4"></i>
                                 Get a free Gemini API key
                             </a>
@@ -388,7 +388,7 @@
 
             <div class="grid md:grid-cols-3 gap-6">
                 <div class="text-center">
-                    <div class="w-16 h-16 bg-acid text-black font-display font-bold text-2xl flex items-center justify-center mx-auto mb-4 clip-notch">01</div>
+                    <div class="w-16 h-16 bg-accent text-black font-display font-bold text-2xl flex items-center justify-center mx-auto mb-4 clip-notch">01</div>
                     <h4 class="font-display text-lg text-chrome mb-2">Press Option+S</h4>
                     <p class="text-gray-400 text-sm">Start recording. The voice panel appears with a pulsing indicator.</p>
                 </div>
@@ -406,7 +406,7 @@
 
             <!-- Voice Recording Screenshot -->
             <div class="mt-10 mb-10">
-                <img src="screenshots/voice-recording-web.png" alt="AudioBash voice recording active" class="w-full max-w-3xl mx-auto rounded-lg border border-acid/30 shadow-xl">
+                <img src="screenshots/voice-recording-web.png" alt="AudioBash voice recording active" class="w-full max-w-3xl mx-auto rounded-lg border border-accent/30 shadow-xl">
                 <p class="text-center text-gray-500 text-sm mt-3">Voice input panel with waveform visualization and RAW/AGENT mode toggle</p>
             </div>
 
@@ -480,7 +480,7 @@
             <div class="grid md:grid-cols-2 gap-6">
                 <div class="bg-panel border border-white/10 p-6">
                     <h4 class="font-display text-chrome mb-4 flex items-center gap-2">
-                        <i data-lucide="mic" class="w-5 h-5 text-acid"></i>
+                        <i data-lucide="mic" class="w-5 h-5 text-accent"></i>
                         Voice input
                     </h4>
                     <ul class="text-gray-400 text-sm space-y-2">
@@ -579,7 +579,7 @@
             </div>
 
             <p class="text-center text-gray-500 text-sm mt-6">
-                Found a bug? <a href="https://github.com/jamditis/audiobash/issues" class="text-acid hover:underline">Report it on GitHub</a>
+                Found a bug? <a href="https://github.com/jamditis/audiobash/issues" class="text-accent hover:underline">Report it on GitHub</a>
             </p>
         </section>
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -33,8 +33,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -57,14 +57,14 @@
         }
 
         ::selection {
-            background-color: #ccff00;
+            background-color: #ff3333;
             color: #000;
         }
 
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: #050505; }
         ::-webkit-scrollbar-thumb { background: #333; }
-        ::-webkit-scrollbar-thumb:hover { background: #ccff00; }
+        ::-webkit-scrollbar-thumb:hover { background: #ff3333; }
 
         .clip-notch {
             clip-path: polygon(
@@ -104,12 +104,12 @@
         }
 
         .toc-link:hover {
-            color: #ccff00;
+            color: #ff3333;
         }
 
         .toc-link.active {
-            color: #ccff00;
-            border-left-color: #ccff00;
+            color: #ff3333;
+            border-left-color: #ff3333;
         }
 
         code {
@@ -145,7 +145,7 @@
 
         th {
             background: #111;
-            color: #ccff00;
+            color: #ff3333;
             font-family: 'Chakra Petch', sans-serif;
             font-weight: 600;
         }
@@ -167,7 +167,7 @@
         <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
                 <a href="index.html" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
-                    <div class="w-10 h-10 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
+                    <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
                         <p class="text-[9px] text-gray-500 tracking-[0.2em]">USER_MANUAL</p>
@@ -180,7 +180,7 @@
                 <a href="https://github.com/jamditis/audiobash" class="text-gray-400 hover:text-chrome transition-colors">
                     <i data-lucide="github" class="w-5 h-5"></i>
                 </a>
-                <a href="index.html#download" class="px-4 py-2 bg-acid text-black font-display font-bold text-sm tracking-wider hover:bg-acid/80 transition-colors clip-notch">
+                <a href="index.html#download" class="px-4 py-2 bg-accent text-black font-display font-bold text-sm tracking-wider hover:bg-accent/80 transition-colors clip-notch">
                     DOWNLOAD
                 </a>
             </div>
@@ -216,8 +216,8 @@
 
             <!-- HEADER -->
             <div class="mb-12">
-                <div class="inline-flex items-center gap-2 px-3 py-1 bg-acid/10 border border-acid/30 text-acid text-xs font-mono mb-4">
-                    <span class="w-2 h-2 bg-acid rounded-full"></span>
+                <div class="inline-flex items-center gap-2 px-3 py-1 bg-accent/10 border border-accent/30 text-accent text-xs font-mono mb-4">
+                    <span class="w-2 h-2 bg-accent rounded-full"></span>
                     v2.0.2
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">USER_MANUAL</h1>
@@ -235,7 +235,7 @@
                 <!-- INTRODUCTION -->
                 <section id="introduction">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">01</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">01</span>
                         INTRODUCTION
                     </h2>
                     <div class="space-y-4">
@@ -245,7 +245,7 @@
                             <h4 class="font-display text-chrome mb-4">Key features</h4>
                             <ul class="space-y-2 text-gray-400">
                                 <li class="flex items-start gap-2">
-                                    <i data-lucide="mic" class="w-4 h-4 text-acid mt-1 shrink-0"></i>
+                                    <i data-lucide="mic" class="w-4 h-4 text-accent mt-1 shrink-0"></i>
                                     <span><strong class="text-chrome">Push-to-talk voice input</strong> - Hold a hotkey to record, release to transcribe and execute</span>
                                 </li>
                                 <li class="flex items-start gap-2">
@@ -257,7 +257,7 @@
                                     <span><strong class="text-chrome">Real terminal environment</strong> - Full PTY (pseudo-terminal) with shell access</span>
                                 </li>
                                 <li class="flex items-start gap-2">
-                                    <i data-lucide="brain" class="w-4 h-4 text-acid mt-1 shrink-0"></i>
+                                    <i data-lucide="brain" class="w-4 h-4 text-accent mt-1 shrink-0"></i>
                                     <span><strong class="text-chrome">Agent mode</strong> - AI-powered command generation for complex tasks</span>
                                 </li>
                                 <li class="flex items-start gap-2">
@@ -272,7 +272,7 @@
                 <!-- INSTALLATION -->
                 <section id="installation">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">02</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">02</span>
                         INSTALLATION
                     </h2>
 
@@ -299,7 +299,7 @@
                                 <span class="w-6 h-6 bg-ice text-black font-display font-bold text-sm flex items-center justify-center shrink-0">1</span>
                                 <div>
                                     <strong class="text-chrome">Download the installer</strong>
-                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-acid hover:underline">releases page</a> and download <code>AudioBash.Setup.2.0.2.exe</code></p>
+                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-accent hover:underline">releases page</a> and download <code>AudioBash.Setup.2.0.2.exe</code></p>
                                 </div>
                             </li>
                             <li class="flex gap-3">
@@ -350,7 +350,7 @@
                                 <span class="w-6 h-6 bg-apple text-black font-display font-bold text-sm flex items-center justify-center shrink-0">1</span>
                                 <div>
                                     <strong class="text-chrome">Download the DMG</strong>
-                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-acid hover:underline">releases page</a> and download:</p>
+                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-accent hover:underline">releases page</a> and download:</p>
                                     <ul class="text-sm mt-2 space-y-1">
                                         <li><strong>Apple Silicon (M1/M2/M3/M4):</strong> <code>AudioBash-2.0.2-arm64.dmg</code></li>
                                         <li><strong>Intel Macs:</strong> <code>AudioBash-2.0.2.dmg</code></li>
@@ -397,7 +397,7 @@
                 <!-- FIRST-TIME SETUP -->
                 <section id="setup">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">03</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">03</span>
                         FIRST-TIME SETUP
                     </h2>
 
@@ -415,7 +415,7 @@
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <td class="text-acid">Gemini (recommended)</td>
+                                        <td class="text-accent">Gemini (recommended)</td>
                                         <td>Fast, accurate, free tier</td>
                                         <td><a href="https://aistudio.google.com/app/apikey" class="text-ice hover:underline">aistudio.google.com</a></td>
                                     </tr>
@@ -463,7 +463,7 @@
                 <!-- USING AUDIOBASH -->
                 <section id="usage">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">04</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">04</span>
                         USING AUDIOBASH
                     </h2>
 
@@ -535,7 +535,7 @@
 
                         <!-- Voice Recording Screenshot -->
                         <div class="mb-6">
-                            <img src="screenshots/voice-recording-web.png" alt="Voice recording active" class="w-full max-w-2xl rounded-lg border border-acid/30">
+                            <img src="screenshots/voice-recording-web.png" alt="Voice recording active" class="w-full max-w-2xl rounded-lg border border-accent/30">
                             <p class="text-gray-500 text-xs mt-2">Voice input panel with waveform visualization and RAW/AGENT mode toggle</p>
                         </div>
 
@@ -549,9 +549,9 @@
                                 <div class="text-2xl mb-1">🟡</div>
                                 <div class="text-yellow-500">Processing</div>
                             </div>
-                            <div class="bg-panel border border-acid/30 p-3 text-center">
+                            <div class="bg-panel border border-accent/30 p-3 text-center">
                                 <div class="text-2xl mb-1">🟢</div>
-                                <div class="text-acid">Ready</div>
+                                <div class="text-accent">Ready</div>
                             </div>
                             <div class="bg-panel border border-white/10 p-3 text-center">
                                 <div class="text-2xl mb-1">⚪</div>
@@ -567,7 +567,7 @@
 
                         <div class="grid md:grid-cols-2 gap-6">
                             <div class="bg-panel border border-white/10 p-6">
-                                <h4 class="font-display text-acid mb-2">Raw mode (default)</h4>
+                                <h4 class="font-display text-accent mb-2">Raw mode (default)</h4>
                                 <p class="text-gray-400 text-sm mb-3">Transcribed text is sent directly to the terminal. What you say is exactly what gets typed.</p>
                                 <p class="text-gray-500 text-xs">Best for: Simple commands, when you know exactly what to type</p>
                                 <div class="bg-void p-3 mt-3 text-sm">
@@ -611,7 +611,7 @@
                 <!-- SETTINGS -->
                 <section id="settings">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">05</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">05</span>
                         SETTINGS
                     </h2>
 
@@ -667,7 +667,7 @@
                         <div>
                             <h4 class="font-display text-chrome mb-3">Transcription providers</h4>
                             <ul class="text-gray-400 space-y-1 text-sm">
-                                <li><strong class="text-acid">Gemini 2.0 Flash</strong> - Google's fast, accurate model (recommended)</li>
+                                <li><strong class="text-accent">Gemini 2.0 Flash</strong> - Google's fast, accurate model (recommended)</li>
                                 <li><strong>OpenAI Whisper</strong> - Industry-standard accuracy</li>
                                 <li><strong>Groq Whisper</strong> - Ultra-fast processing</li>
                                 <li><strong>Claude</strong> - Uses Anthropic's model</li>
@@ -693,7 +693,7 @@
                 <!-- TROUBLESHOOTING -->
                 <section id="troubleshooting">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">06</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">06</span>
                         TROUBLESHOOTING
                     </h2>
 
@@ -755,7 +755,7 @@
                 <!-- FAQ -->
                 <section id="faq">
                     <h2 class="font-display text-2xl text-chrome mb-6 flex items-center gap-3">
-                        <span class="w-8 h-8 bg-acidDim border border-acid/30 flex items-center justify-center text-acid text-sm">07</span>
+                        <span class="w-8 h-8 bg-accentDim border border-accent/30 flex items-center justify-center text-accent text-sm">07</span>
                         FAQ
                     </h2>
 
@@ -785,7 +785,7 @@
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
                             <h4 class="text-chrome mb-2">How do I report bugs or request features?</h4>
-                            <p class="text-gray-400 text-sm">Visit <a href="https://github.com/jamditis/audiobash/issues" class="text-acid hover:underline">github.com/jamditis/audiobash/issues</a></p>
+                            <p class="text-gray-400 text-sm">Visit <a href="https://github.com/jamditis/audiobash/issues" class="text-accent hover:underline">github.com/jamditis/audiobash/issues</a></p>
                         </div>
                     </div>
                 </section>
@@ -797,9 +797,9 @@
                 <div class="flex flex-col md:flex-row items-center justify-between gap-4 text-gray-500 text-sm">
                     <div>AudioBash v2.0.2 - Voice-controlled terminal for Claude Code</div>
                     <div class="flex items-center gap-4">
-                        <a href="https://github.com/jamditis/audiobash" class="hover:text-acid transition-colors">GitHub</a>
-                        <a href="https://github.com/jamditis/audiobash/issues" class="hover:text-acid transition-colors">Issues</a>
-                        <a href="https://github.com/jamditis" class="hover:text-acid transition-colors">@jamditis</a>
+                        <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">GitHub</a>
+                        <a href="https://github.com/jamditis/audiobash/issues" class="hover:text-accent transition-colors">Issues</a>
+                        <a href="https://github.com/jamditis" class="hover:text-accent transition-colors">@jamditis</a>
                     </div>
                 </div>
             </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -33,8 +33,8 @@
                         panel: '#0a0a0a',
                         surface: '#111111',
                         chrome: '#e5e5e5',
-                        acid: '#ccff00',
-                        acidDim: 'rgba(204, 255, 0, 0.1)',
+                        accent: '#ff3333',
+                        accentDim: 'rgba(255, 51, 51, 0.1)',
                         signal: '#ff2a2a',
                         signalDim: 'rgba(255, 42, 42, 0.1)',
                         ice: '#00f0ff',
@@ -57,14 +57,14 @@
         }
 
         ::selection {
-            background-color: #ccff00;
+            background-color: #ff3333;
             color: #000;
         }
 
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: #050505; }
         ::-webkit-scrollbar-thumb { background: #333; }
-        ::-webkit-scrollbar-thumb:hover { background: #ccff00; }
+        ::-webkit-scrollbar-thumb:hover { background: #ff3333; }
 
         .clip-notch {
             clip-path: polygon(
@@ -102,11 +102,11 @@
         }
 
         .release-card:hover {
-            border-left-color: #ccff00;
+            border-left-color: #ff3333;
         }
 
         .release-card.latest {
-            border-left-color: #ccff00;
+            border-left-color: #ff3333;
         }
     </style>
 </head>
@@ -122,7 +122,7 @@
         <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
             <div class="flex items-center gap-3">
                 <a href="index.html" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
-                    <div class="w-10 h-10 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
+                    <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
                         <p class="text-[9px] text-gray-500 tracking-[0.2em]">RELEASE_NOTES</p>
@@ -136,7 +136,7 @@
                 <a href="https://github.com/jamditis/audiobash" class="text-gray-400 hover:text-chrome transition-colors">
                     <i data-lucide="github" class="w-5 h-5"></i>
                 </a>
-                <a href="index.html#download" class="px-4 py-2 bg-acid text-black font-display font-bold text-sm tracking-wider hover:bg-acid/80 transition-colors clip-notch">
+                <a href="index.html#download" class="px-4 py-2 bg-accent text-black font-display font-bold text-sm tracking-wider hover:bg-accent/80 transition-colors clip-notch">
                     DOWNLOAD
                 </a>
             </div>
@@ -155,10 +155,10 @@
         <div class="space-y-8">
 
             <!-- v2.0.2 -->
-            <article class="release-card latest bg-panel border border-acid/30 p-6">
+            <article class="release-card latest bg-panel border border-accent/30 p-6">
                 <div class="flex flex-wrap items-center gap-3 mb-4">
-                    <span class="px-3 py-1 bg-acid text-black font-display font-bold text-sm">v2.0.2</span>
-                    <span class="px-3 py-1 bg-acid/20 text-acid text-xs font-mono">LATEST</span>
+                    <span class="px-3 py-1 bg-accent text-black font-display font-bold text-sm">v2.0.2</span>
+                    <span class="px-3 py-1 bg-accent/20 text-accent text-xs font-mono">LATEST</span>
                     <span class="text-gray-500 text-sm">January 2, 2026</span>
                 </div>
 
@@ -187,7 +187,7 @@
 
                 <div class="grid md:grid-cols-2 gap-6">
                     <div>
-                        <h4 class="font-display text-acid text-sm mb-2">Added</h4>
+                        <h4 class="font-display text-accent text-sm mb-2">Added</h4>
                         <ul class="text-gray-400 text-sm space-y-1">
                             <li>• macOS stress test suite (18 automated tests)</li>
                             <li>• PTY spawn/destroy cycle testing</li>
@@ -250,7 +250,7 @@
 
                 <div class="grid md:grid-cols-2 gap-6">
                     <div>
-                        <h4 class="font-display text-acid text-sm mb-2">Added</h4>
+                        <h4 class="font-display text-accent text-sm mb-2">Added</h4>
                         <ul class="text-gray-400 text-sm space-y-1">
                             <li>• Full macOS support with native arm64 and x64 builds</li>
                             <li>• DMG installer for macOS</li>
@@ -271,7 +271,7 @@
                 </div>
 
                 <div class="mt-4 pt-4 border-t border-white/10">
-                    <a href="macos.html" class="text-acid hover:underline text-sm">Read the full macOS announcement →</a>
+                    <a href="macos.html" class="text-accent hover:underline text-sm">Read the full macOS announcement →</a>
                 </div>
             </article>
 
@@ -288,7 +288,7 @@
 
                 <div class="grid md:grid-cols-2 gap-6">
                     <div>
-                        <h4 class="font-display text-acid text-sm mb-2">Added</h4>
+                        <h4 class="font-display text-accent text-sm mb-2">Added</h4>
                         <ul class="text-gray-400 text-sm space-y-1">
                             <li>• Custom instructions for raw and agent modes</li>
                             <li>• Custom vocabulary/pronunciations mapping</li>
@@ -320,7 +320,7 @@
                 <h2 class="font-display text-xl text-chrome mb-4">Split view & tab management</h2>
 
                 <div>
-                    <h4 class="font-display text-acid text-sm mb-2">Added</h4>
+                    <h4 class="font-display text-accent text-sm mb-2">Added</h4>
                     <ul class="text-gray-400 text-sm space-y-1">
                         <li>• Split view with 5 layout modes (single, horizontal, vertical, 2x2, 1+2)</li>
                         <li>• Resizable terminal panes with drag dividers</li>
@@ -359,7 +359,7 @@
                 <h2 class="font-display text-xl text-chrome mb-4">Context-aware agent & quick navigation</h2>
 
                 <div>
-                    <h4 class="font-display text-acid text-sm mb-2">Added</h4>
+                    <h4 class="font-display text-accent text-sm mb-2">Added</h4>
                     <ul class="text-gray-400 text-sm space-y-1">
                         <li>• Context-aware agent mode (understands cwd, recent output, errors)</li>
                         <li>• Quick directory navigation panel</li>
@@ -381,7 +381,7 @@
                 <p class="text-gray-400 mb-4">The first public release of AudioBash!</p>
 
                 <div>
-                    <h4 class="font-display text-acid text-sm mb-2">Features</h4>
+                    <h4 class="font-display text-accent text-sm mb-2">Features</h4>
                     <ul class="text-gray-400 text-sm space-y-1">
                         <li>• Voice-to-terminal transcription</li>
                         <li>• Multi-tab terminal support (up to 4 tabs)</li>
@@ -403,7 +403,7 @@
             <div class="bg-panel border border-white/10 p-6">
                 <div class="grid md:grid-cols-2 gap-8">
                     <div>
-                        <h4 class="font-display text-acid text-sm mb-3">Planned features</h4>
+                        <h4 class="font-display text-accent text-sm mb-3">Planned features</h4>
                         <ul class="text-gray-400 text-sm space-y-2">
                             <li class="flex items-center gap-2">
                                 <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
@@ -465,10 +465,10 @@
                 AUDIOBASH // RELEASE NOTES // MIT LICENSE
             </div>
             <div class="flex items-center gap-4 text-gray-500 text-sm">
-                <a href="index.html" class="hover:text-acid transition-colors">Home</a>
-                <a href="manual.html" class="hover:text-acid transition-colors">Manual</a>
-                <a href="macos.html" class="hover:text-acid transition-colors">macOS</a>
-                <a href="https://github.com/jamditis" class="hover:text-acid transition-colors">@jamditis</a>
+                <a href="index.html" class="hover:text-accent transition-colors">Home</a>
+                <a href="manual.html" class="hover:text-accent transition-colors">Manual</a>
+                <a href="macos.html" class="hover:text-accent transition-colors">macOS</a>
+                <a href="https://github.com/jamditis" class="hover:text-accent transition-colors">@jamditis</a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Change the primary accent color from green (#ccff00) to red (#ff3333) to match the actual app interface. This affects:
- index.html (landing page)
- manual.html (user manual)
- releases.html (release notes)
- blog.html (blog index)
- blog/end-user-testing.html (blog article)
- macos.html (macOS announcement page)

The red theme (#ff3333) is consistent with the app's CSS variables and provides visual coherence between the documentation and the actual AudioBash application.