### PR TITLE
Claude/add GitHub favicon v0i l4

### DIFF
--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" fill="#050505"/>
   <!-- Terminal prompt bracket -->
-  <path d="M6 8 L12 16 L6 24" stroke="#ff2a2a" stroke-width="3" stroke-linecap="square" fill="none"/>
+  <path d="M6 8 L12 16 L6 24" stroke="#ff3333" stroke-width="3" stroke-linecap="square" fill="none"/>
   <!-- Audio waves -->
-  <rect x="16" y="13" width="2" height="6" fill="#ff2a2a"/>
-  <rect x="20" y="10" width="2" height="12" fill="#ff2a2a"/>
-  <rect x="24" y="7" width="2" height="18" fill="#ff2a2a"/>
+  <rect x="16" y="13" width="2" height="6" fill="#ff3333"/>
+  <rect x="20" y="10" width="2" height="12" fill="#ff3333"/>
+  <rect x="24" y="7" width="2" height="18" fill="#ff3333"/>
 </svg>


### PR DESCRIPTION
This pull request adds a favicon to all documentation pages to improve site branding and user experience. The favicon is now consistently referenced across the main site, blog, manual, release notes, macOS page, and remote interface.

**Documentation updates:**

* Added a `<link rel="icon" type="image/svg+xml" href="favicon.svg">` tag to the following HTML files to include the favicon:
  - `docs/index.html`
  - `docs/blog.html`
  - `docs/manual.html`
  - `docs/releases.html`
  - `docs/macos.html`

* Updated blog subpage and remote interface to reference the favicon with the correct relative path:
  - `docs/blog/end-user-testing.html`
  - `docs/remote/index.html`