### PR TITLE
Fix text overflow issues in documentation pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -420,7 +420,7 @@
 
                     <div class="flex items-start gap-6">
                         <div class="w-16 h-16 bg-accent text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">01</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-xl text-chrome mb-2">ACTIVATE</h4>
                             <p class="text-gray-400 font-mono">Press your configured hotkey (Alt+S on Windows, Option+S on Mac) to start voice capture. The floating overlay appears.</p>
                         </div>
@@ -428,7 +428,7 @@
 
                     <div class="flex items-start gap-6">
                         <div class="w-16 h-16 bg-ice text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">02</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-xl text-chrome mb-2">SPEAK</h4>
                             <p class="text-gray-400 font-mono">Say your command naturally. "List all JavaScript files" or "Git status". The AI transcribes and converts.</p>
                         </div>
@@ -436,7 +436,7 @@
 
                     <div class="flex items-start gap-6">
                         <div class="w-16 h-16 bg-signal text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">03</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-xl text-chrome mb-2">EXECUTE</h4>
                             <p class="text-gray-400 font-mono">Command is sent to your active terminal and executed. Results appear instantly. Hands stay on keyboard.</p>
                         </div>

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -159,6 +159,8 @@
             padding: 1em;
             overflow-x: auto;
             border-radius: 4px;
+            white-space: pre-wrap;
+            word-break: break-all;
         }
 
         pre code {
@@ -301,7 +303,7 @@
                     <!-- Step 1 -->
                     <div class="flex gap-4">
                         <div class="w-10 h-10 bg-apple text-black font-display font-bold flex items-center justify-center shrink-0">1</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Download the DMG</h4>
                             <p class="text-gray-400 text-sm mb-3">Choose the right version for your Mac:</p>
                             <div class="flex flex-wrap gap-3">
@@ -321,7 +323,7 @@
                     <!-- Step 2 -->
                     <div class="flex gap-4">
                         <div class="w-10 h-10 bg-apple text-black font-display font-bold flex items-center justify-center shrink-0">2</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Drag to Applications</h4>
                             <p class="text-gray-400 text-sm">Open the DMG and drag AudioBash.app to your Applications folder.</p>
                         </div>
@@ -330,7 +332,7 @@
                     <!-- Step 3 -->
                     <div class="flex gap-4">
                         <div class="w-10 h-10 bg-signal text-black font-display font-bold flex items-center justify-center shrink-0">3</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Bypass Gatekeeper (important!)</h4>
                             <p class="text-gray-400 text-sm mb-3">AudioBash isn't notarized by Apple (costs $99/year), so you need to bypass Gatekeeper on first launch:</p>
 
@@ -349,7 +351,7 @@
                     <!-- Step 4 -->
                     <div class="flex gap-4">
                         <div class="w-10 h-10 bg-apple text-black font-display font-bold flex items-center justify-center shrink-0">4</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Grant permissions</h4>
                             <p class="text-gray-400 text-sm mb-3">macOS will ask for these permissions on first use:</p>
                             <ul class="text-gray-400 text-sm space-y-2">
@@ -369,7 +371,7 @@
                     <!-- Step 5 -->
                     <div class="flex gap-4">
                         <div class="w-10 h-10 bg-accent text-black font-display font-bold flex items-center justify-center shrink-0">5</div>
-                        <div>
+                        <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Add your API key</h4>
                             <p class="text-gray-400 text-sm mb-3">Click the gear icon and enter your transcription API key. We recommend Gemini (free tier available):</p>
                             <a href="https://aistudio.google.com/app/apikey" class="inline-flex items-center gap-2 text-accent hover:underline text-sm">

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -128,6 +128,8 @@
             padding: 1em;
             overflow-x: auto;
             border-radius: 4px;
+            white-space: pre-wrap;
+            word-break: break-all;
         }
 
         pre code {


### PR DESCRIPTION
- Add min-w-0 and flex-1 to flex content containers to allow proper text wrapping in installation steps
- Add white-space: pre-wrap and word-break: break-all to pre elements to prevent code blocks from overflowing
- Fixes text truncation in macOS installation instructions (Gatekeeper bypass steps, terminal commands)