### PR TITLE
Update runner and provisioner versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,13 +125,13 @@ jobs:
         run: ls -R artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
+          fail_on_unmatched_files: false
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/*.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for release creation, primarily by upgrading the `softprops/action-gh-release` action to a newer version and updating its configuration options.

**Release workflow updates:**

* Upgraded `softprops/action-gh-release` from version `v1` to `v2` for improved reliability and new features.
* Added the `fail_on_unmatched_files: false` option to prevent workflow failures if no files match the specified patterns.
* Changed the authentication environment variable from `GITHUB_TOKEN` to `token` as required by the new action version.