### PR TITLE
Update GitHub Pages for latest version

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -114,7 +114,7 @@
                     <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
-                        <p class="text-[9px] text-gray-500 tracking-[0.2em]">v2.0.2 // VOICE_TERMINAL</p>
+                        <p class="text-[9px] text-gray-500 tracking-[0.2em]">v2.1.0 // VOICE_TERMINAL</p>
                     </div>
                 </a>
             </div>
@@ -191,7 +191,7 @@
     <footer class="border-t border-white/10 py-8 px-6">
         <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
             <div class="text-[10px] text-gray-600 font-mono">
-                AUDIOBASH v2.0.2 // BLOG // MIT LICENSE
+                AUDIOBASH v2.1.0 // BLOG // MIT LICENSE
             </div>
             <div class="flex items-center gap-4 text-gray-500">
                 <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AudioBash for macOS - Now Available</title>
-    <meta name="description" content="AudioBash v2.0 brings native macOS support! Voice-controlled terminal for developers, now on Apple Silicon and Intel Macs.">
+    <meta name="description" content="AudioBash v2.1 brings ElevenLabs Scribe v2 real-time transcription! Voice-controlled terminal for developers, on Apple Silicon and Intel Macs.">
 
     <!-- Open Graph -->
     <meta property="og:title" content="AudioBash for macOS - Now Available">
@@ -211,7 +211,7 @@
             <!-- Badge -->
             <div class="inline-flex items-center gap-2 px-4 py-2 bg-appleDim border border-apple/30 text-apple text-sm font-mono mb-8">
                 <span class="w-2 h-2 bg-apple rounded-full animate-pulse-slow"></span>
-                v2.0.2 — January 2, 2026
+                v2.1.0 — ElevenLabs Real-time
             </div>
 
             <!-- Apple Icon -->
@@ -232,13 +232,13 @@
 
             <!-- Download Buttons -->
             <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-6">
-                <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash-2.0.2-arm64.dmg" class="px-8 py-4 apple-gradient text-black font-display font-bold text-lg tracking-wider hover:opacity-90 transition-all clip-notch animate-glow-apple">
+                <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash-2.1.0-arm64.dmg" class="px-8 py-4 apple-gradient text-black font-display font-bold text-lg tracking-wider hover:opacity-90 transition-all clip-notch animate-glow-apple">
                     <span class="flex items-center gap-2">
                         <i data-lucide="cpu" class="w-5 h-5"></i>
                         Apple Silicon (M1/M2/M3/M4)
                     </span>
                 </a>
-                <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash-2.0.2.dmg" class="px-8 py-4 border-2 border-apple text-apple font-display font-bold text-lg tracking-wider hover:bg-appleDim transition-all">
+                <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash-2.1.0.dmg" class="px-8 py-4 border-2 border-apple text-apple font-display font-bold text-lg tracking-wider hover:bg-appleDim transition-all">
                     <span class="flex items-center gap-2">
                         <i data-lucide="laptop" class="w-5 h-5"></i>
                         Intel Mac
@@ -247,7 +247,7 @@
             </div>
 
             <p class="text-gray-500 text-sm">
-                Also available: <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash.Setup.2.0.2.exe" class="text-ice hover:underline">Windows installer</a>
+                Also available: <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash.Setup.2.1.0.exe" class="text-ice hover:underline">Windows installer</a>
             </p>
 
             <!-- App Preview Screenshot -->
@@ -307,11 +307,11 @@
                             <h4 class="font-display text-chrome text-lg mb-2">Download the DMG</h4>
                             <p class="text-gray-400 text-sm mb-3">Choose the right version for your Mac:</p>
                             <div class="flex flex-wrap gap-3">
-                                <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash-2.0.2-arm64.dmg" class="inline-flex items-center gap-2 px-4 py-2 bg-appleDim border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                                <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash-2.1.0-arm64.dmg" class="inline-flex items-center gap-2 px-4 py-2 bg-appleDim border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                                     <i data-lucide="download" class="w-4 h-4"></i>
                                     Apple Silicon DMG
                                 </a>
-                                <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash-2.0.2.dmg" class="inline-flex items-center gap-2 px-4 py-2 bg-void border border-white/20 text-gray-400 text-sm hover:border-apple hover:text-apple transition-colors">
+                                <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash-2.1.0.dmg" class="inline-flex items-center gap-2 px-4 py-2 bg-void border border-white/20 text-gray-400 text-sm hover:border-apple hover:text-apple transition-colors">
                                     <i data-lucide="download" class="w-4 h-4"></i>
                                     Intel DMG
                                 </a>
@@ -459,7 +459,7 @@
         <section class="mb-20 section-animate">
             <div class="text-center mb-10">
                 <h2 class="font-display text-3xl text-chrome mb-2">FULL_FEATURES</h2>
-                <p class="text-gray-500">Everything included in v2.0.2</p>
+                <p class="text-gray-500">Everything included in v2.1.0</p>
             </div>
 
             <!-- Feature Screenshots Gallery -->
@@ -490,10 +490,10 @@
                     </h4>
                     <ul class="text-gray-400 text-sm space-y-2">
                         <li>• Push-to-talk with global hotkey</li>
+                        <li>• <strong class="text-ice">NEW:</strong> ElevenLabs Scribe v2 real-time (~150ms)</li>
                         <li>• Multiple AI providers: Gemini, OpenAI, Claude, Groq</li>
                         <li>• Raw mode (verbatim) or Agent mode (AI interprets intent)</li>
                         <li>• Custom vocabulary for technical terms</li>
-                        <li>• Custom instructions per mode</li>
                     </ul>
                 </div>
 
@@ -597,7 +597,7 @@
                 <p class="text-gray-400 mb-8 relative">Free and open source. Your voice, your terminal.</p>
 
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-4 relative">
-                    <a href="https://github.com/jamditis/audiobash/releases/download/v2.0.2/AudioBash-2.0.2-arm64.dmg" class="px-8 py-4 apple-gradient text-black font-display font-bold text-lg tracking-wider hover:opacity-90 transition-all clip-notch">
+                    <a href="https://github.com/jamditis/audiobash/releases/download/v2.1.0/AudioBash-2.1.0-arm64.dmg" class="px-8 py-4 apple-gradient text-black font-display font-bold text-lg tracking-wider hover:opacity-90 transition-all clip-notch">
                         DOWNLOAD FOR MAC
                     </a>
                     <a href="https://github.com/jamditis/audiobash" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-apple hover:text-apple transition-all">
@@ -616,7 +616,7 @@
     <footer class="border-t border-white/10 py-8 px-6 relative z-10">
         <div class="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
             <div class="text-[10px] text-gray-600 font-mono">
-                AUDIOBASH v2.0.2 // macOS EDITION // MIT LICENSE
+                AUDIOBASH v2.1.0 // macOS EDITION // MIT LICENSE
             </div>
             <div class="flex items-center gap-4 text-gray-500 text-sm">
                 <a href="index.html" class="hover:text-apple transition-colors">Home</a>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -223,7 +223,7 @@
             <div class="mb-12">
                 <div class="inline-flex items-center gap-2 px-3 py-1 bg-accent/10 border border-accent/30 text-accent text-xs font-mono mb-4">
                     <span class="w-2 h-2 bg-accent rounded-full"></span>
-                    v2.0.2
+                    v2.1.0
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">USER_MANUAL</h1>
                 <p class="text-gray-400 text-lg">Complete guide to installing and using AudioBash on Windows and macOS.</p>
@@ -304,7 +304,7 @@
                                 <span class="w-6 h-6 bg-ice text-black font-display font-bold text-sm flex items-center justify-center shrink-0">1</span>
                                 <div>
                                     <strong class="text-chrome">Download the installer</strong>
-                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-accent hover:underline">releases page</a> and download <code>AudioBash.Setup.2.0.2.exe</code></p>
+                                    <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-accent hover:underline">releases page</a> and download <code>AudioBash.Setup.2.1.0.exe</code></p>
                                 </div>
                             </li>
                             <li class="flex gap-3">
@@ -357,8 +357,8 @@
                                     <strong class="text-chrome">Download the DMG</strong>
                                     <p class="text-sm mt-1">Visit the <a href="https://github.com/jamditis/audiobash/releases" class="text-accent hover:underline">releases page</a> and download:</p>
                                     <ul class="text-sm mt-2 space-y-1">
-                                        <li><strong>Apple Silicon (M1/M2/M3/M4):</strong> <code>AudioBash-2.0.2-arm64.dmg</code></li>
-                                        <li><strong>Intel Macs:</strong> <code>AudioBash-2.0.2.dmg</code></li>
+                                        <li><strong>Apple Silicon (M1/M2/M3/M4):</strong> <code>AudioBash-2.1.0-arm64.dmg</code></li>
+                                        <li><strong>Intel Macs:</strong> <code>AudioBash-2.1.0.dmg</code></li>
                                     </ul>
                                 </div>
                             </li>
@@ -423,6 +423,11 @@
                                         <td class="text-accent">Gemini (recommended)</td>
                                         <td>Fast, accurate, free tier</td>
                                         <td><a href="https://aistudio.google.com/app/apikey" class="text-ice hover:underline">aistudio.google.com</a></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="text-ice">ElevenLabs Scribe v2</td>
+                                        <td>Real-time (~150ms), VAD auto-commit</td>
+                                        <td><a href="https://elevenlabs.io/app/settings/api-keys" class="text-ice hover:underline">elevenlabs.io</a></td>
                                     </tr>
                                     <tr>
                                         <td>OpenAI Whisper</td>
@@ -673,6 +678,7 @@
                             <h4 class="font-display text-chrome mb-3">Transcription providers</h4>
                             <ul class="text-gray-400 space-y-1 text-sm">
                                 <li><strong class="text-accent">Gemini 2.0 Flash</strong> - Google's fast, accurate model (recommended)</li>
+                                <li><strong class="text-ice">ElevenLabs Scribe v2</strong> - Real-time WebSocket streaming (~150ms latency)</li>
                                 <li><strong>OpenAI Whisper</strong> - Industry-standard accuracy</li>
                                 <li><strong>Groq Whisper</strong> - Ultra-fast processing</li>
                                 <li><strong>Claude</strong> - Uses Anthropic's model</li>
@@ -804,7 +810,7 @@
             <!-- FOOTER -->
             <div class="mt-16 pt-8 border-t border-white/10">
                 <div class="flex flex-col md:flex-row items-center justify-between gap-4 text-gray-500 text-sm">
-                    <div>AudioBash v2.0.2 - Voice-controlled terminal for Claude Code</div>
+                    <div>AudioBash v2.1.0 - Voice-controlled terminal for Claude Code</div>
                     <div class="flex items-center gap-4">
                         <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">GitHub</a>
                         <a href="https://github.com/jamditis/audiobash/issues" class="hover:text-accent transition-colors">Issues</a>


### PR DESCRIPTION
- Update version references from v2.0.2 to v2.1.0 across all docs
- Update download links to point to v2.1.0 release assets
- Add ElevenLabs Scribe v2 as transcription provider in manual
- Highlight real-time (~150ms) WebSocket streaming feature
- Update macOS page with new ElevenLabs feature in voice input section