### PR TITLE
make pane splits visible after layout changes

### DIFF
--- a/src/components/PaneManager.tsx
+++ b/src/components/PaneManager.tsx
@@ -62,6 +62,7 @@ const PaneManager = forwardRef<PaneManagerHandle, PaneManagerProps>(({
     const newTabId = await onCreateTerminal();
     terminalPoolRef.current.push(newTabId);
     setPaneRoot(prev => splitPane(prev, focusedPaneId, direction, newTabId));
+    setZoomedPaneId(null);
   }, [focusedPaneId, paneRoot, onCreateTerminal]);
 
   const handleClose = useCallback((paneId: string) => {

--- a/src/components/PaneNode.tsx
+++ b/src/components/PaneNode.tsx
@@ -52,8 +52,8 @@ const PaneNodeComponent: React.FC<PaneNodeProps> = ({
   }
 
   const isHorizontal = node.direction === 'horizontal';
-  const firstSize = `${node.ratio * 100}%`;
-  const secondSize = `${(1 - node.ratio) * 100}%`;
+  const firstFlex = `${node.ratio} 1 0`;
+  const secondFlex = `${1 - node.ratio} 1 0`;
 
   const handleResize = (delta: number) => {
     if (!containerRef.current) return;
@@ -67,7 +67,7 @@ const PaneNodeComponent: React.FC<PaneNodeProps> = ({
       ref={containerRef}
       className={`h-full w-full flex ${isHorizontal ? 'flex-col' : 'flex-row'}`}
     >
-      <div style={{ [isHorizontal ? 'height' : 'width']: firstSize }} className="overflow-hidden">
+      <div style={{ flex: firstFlex }} className="min-w-0 min-h-0 overflow-hidden">
         <PaneNodeComponent
           node={node.children[0]}
           focusedId={focusedId} zoomedId={zoomedId} isRecording={isRecording}
@@ -81,7 +81,7 @@ const PaneNodeComponent: React.FC<PaneNodeProps> = ({
         onResize={handleResize}
         onEqualize={() => onEqualize(node.id)}
       />
-      <div style={{ [isHorizontal ? 'height' : 'width']: secondSize }} className="overflow-hidden">
+      <div style={{ flex: secondFlex }} className="min-w-0 min-h-0 overflow-hidden">
         <PaneNodeComponent
           node={node.children[1]}
           focusedId={focusedId} zoomedId={zoomedId} isRecording={isRecording}

--- a/tests/components/PaneManager.test.tsx
+++ b/tests/components/PaneManager.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import PaneManager from '../../src/components/PaneManager';
+
+vi.mock('../../src/hooks/usePaneActivity', () => ({
+  usePaneActivity: () => new Map(),
+}));
+
+vi.mock('../../src/components/Terminal', () => ({
+  default: ({ tabId, isFocused }: { tabId: string; isFocused: boolean }) => (
+    <div data-testid="terminal" data-tab-id={tabId} data-focused={String(isFocused)} />
+  ),
+}));
+
+function renderPaneManager(onCreateTerminal = vi.fn<() => Promise<string>>()) {
+  return render(
+    <PaneManager
+      initialTerminalId="tab-1"
+      isRecording={false}
+      cliNotificationsEnabled={true}
+      fontSize={14}
+      onCreateTerminal={onCreateTerminal}
+      onCloseTerminal={vi.fn()}
+    />,
+  );
+}
+
+describe('PaneManager layout controls', () => {
+  it('renders a four-pane grid from the grid preset button', async () => {
+    const onCreateTerminal = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('tab-2')
+      .mockResolvedValueOnce('tab-3')
+      .mockResolvedValueOnce('tab-4');
+
+    renderPaneManager(onCreateTerminal);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grid 2x2' }));
+
+    await waitFor(() => expect(screen.getAllByTestId('terminal')).toHaveLength(4));
+  });
+
+  it('clears zoom when splitting so the new pane is visible immediately', async () => {
+    const onCreateTerminal = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('tab-2')
+      .mockResolvedValueOnce('tab-3');
+
+    renderPaneManager(onCreateTerminal);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Split vertical' }));
+    await waitFor(() => expect(screen.getAllByTestId('terminal')).toHaveLength(2));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle pane zoom' }));
+    expect(screen.getByText('ZOOMED')).toBeInTheDocument();
+    expect(screen.getAllByTestId('terminal')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Split horizontal' }));
+
+    await waitFor(() => expect(screen.queryByText('ZOOMED')).not.toBeInTheDocument());
+    expect(screen.getAllByTestId('terminal')).toHaveLength(3);
+  });
+});

--- a/tests/components/PaneManager.test.tsx
+++ b/tests/components/PaneManager.test.tsx
@@ -58,7 +58,12 @@ describe('PaneManager layout controls', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Split horizontal' }));
 
-    await waitFor(() => expect(screen.queryByText('ZOOMED')).not.toBeInTheDocument());
-    expect(screen.getAllByTestId('terminal')).toHaveLength(3);
+    // The split runs an async onCreateTerminal alongside the zoom-clear state update, so the
+    // ZOOMED label and the third pane can settle on different ticks. Wait for both conditions
+    // together to avoid asserting the pane count before the new pane has rendered.
+    await waitFor(() => {
+      expect(screen.queryByText('ZOOMED')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('terminal')).toHaveLength(3);
+    });
   });
 });

--- a/tests/components/PaneNode.test.tsx
+++ b/tests/components/PaneNode.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import PaneNodeComponent from '../../src/components/PaneNode';
+import { createLeaf, splitPane } from '../../src/utils/paneTree';
+
+vi.mock('../../src/components/Terminal', () => ({
+  default: ({ tabId }: { tabId: string }) => <div data-testid="terminal" data-tab-id={tabId} />,
+}));
+
+vi.mock('../../src/components/PaneDivider', () => ({
+  default: ({ direction }: { direction: string }) => <div data-testid="pane-divider" data-direction={direction} />,
+}));
+
+function renderPaneTree() {
+  const root = createLeaf('tab-1');
+  const split = splitPane(root, root.id, 'vertical', 'tab-2');
+
+  return render(
+    <PaneNodeComponent
+      node={split}
+      focusedId={root.id}
+      zoomedId={null}
+      isRecording={false}
+      cliNotificationsEnabled={true}
+      fontSize={14}
+      activityStates={new Map()}
+      paneColors={new Map()}
+      onFocus={vi.fn()}
+      onResize={vi.fn()}
+      onEqualize={vi.fn()}
+    />,
+  );
+}
+
+describe('PaneNodeComponent split layout', () => {
+  it('allows split children to shrink inside the flex layout', () => {
+    const { getAllByTestId } = renderPaneTree();
+
+    const terminals = getAllByTestId('terminal');
+    expect(terminals).toHaveLength(2);
+
+    const splitChildWrappers = terminals.map(terminal => terminal.parentElement?.parentElement);
+    expect(splitChildWrappers[0]).toHaveClass('min-w-0');
+    expect(splitChildWrappers[0]).toHaveClass('min-h-0');
+    expect(splitChildWrappers[1]).toHaveClass('min-w-0');
+    expect(splitChildWrappers[1]).toHaveClass('min-h-0');
+  });
+});


### PR DESCRIPTION
### Motivation

- fix cases where split/grid actions produced new leaves but the UI still showed a single pane because child panes could not shrink or because zoom masked updates. 
- add regression tests to catch split/grid and zoom-interaction regressions early. 

### Description

- update `src/components/PaneNode.tsx` to use proportional flex sizing (`flex: <ratio> 1 0`) and add `min-w-0 min-h-0` on wrapper elements so split children can shrink instead of forcing a single visible pane. 
- update `src/components/PaneManager.tsx` to clear `zoomedPaneId` after performing a split (`setZoomedPaneId(null)`) so newly created panes are visible immediately. 
- add component tests `tests/components/PaneManager.test.tsx` and `tests/components/PaneNode.test.tsx` that cover the `grid-2x2` preset, split-after-zoom behavior, and flex shrink behavior. 
- leave the `paneTree` model and existing split/preset logic unchanged. 

### Testing

- ran targeted tests with `npm test -- --run tests/components/PaneManager.test.tsx tests/components/PaneNode.test.tsx tests/unit/paneTree.test.ts` and all targeted tests passed. 
- ran full test suite with `SHELL=/bin/bash npm test` to avoid an environment-dependent integration failure and the full suite passed. 
- ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ba2d98988324a75a039368170592)