### PR TITLE
docs: accuracy and content refresh for the marketing site

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -86,7 +86,7 @@ AudioBash is a voice-controlled terminal application designed to work with Claud
 ### macOS installation
 
 #### System requirements
-- macOS 11 (Big Sur) or later
+- macOS 12 (Monterey) or later
 - Apple Silicon (M1/M2/M3/M4) or Intel processor
 - 4GB RAM minimum (8GB recommended)
 - 200MB disk space

--- a/docs/about.html
+++ b/docs/about.html
@@ -113,7 +113,7 @@
                     <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                     <div>
                         <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
-                        <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v2.3.5 // VOICE_TERMINAL</p>
+                        <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v3.2.0 // VOICE_TERMINAL</p>
                     </div>
                 </a>
             </div>
@@ -161,7 +161,7 @@
                         <p class="text-gray-400 leading-relaxed mb-6">
                             I build tools for journalists and developers. By day, I coordinate collaborative reporting projects
                             and create AI resources for newsrooms at the <a href="https://centerforcooperativemedia.org" class="text-ice hover:text-chrome transition-colors">Center for Cooperative Media</a>.
-                            By night, I write code that makes voice interaction with terminals actually useful.
+                            By night, I write code that makes voice interaction with terminals useful.
                         </p>
 
                         <p class="text-gray-400 leading-relaxed mb-6">
@@ -348,7 +348,7 @@
     <footer class="border-t border-white/10 py-8 px-6">
         <div class="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
             <div class="text-[10px] text-gray-600 font-mono">
-                <span data-version="AUDIOBASH v{version} // ABOUT // MIT LICENSE">AUDIOBASH v2.3.5 // ABOUT // MIT LICENSE</span>
+                <span data-version="AUDIOBASH v{version} // ABOUT // MIT LICENSE">AUDIOBASH v3.2.0 // ABOUT // MIT LICENSE</span>
             </div>
             <div class="flex items-center gap-4 text-gray-500">
                 <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 
     <!-- Open Graph -->
     <meta property="og:title" content="AudioBash - Voice-controlled terminal">
-    <meta property="og:description" content="Speak commands, execute instantly. Multi-tab terminal with AI-powered voice transcription. Available for Windows and macOS.">
+    <meta property="og:description" content="Speak commands and watch them run. Multi-tab terminal with voice transcription from Gemini, ElevenLabs, or local Whisper. Windows and macOS.">
     <meta property="og:type" content="website">
 
     <!-- Favicon -->
@@ -245,8 +245,8 @@
 
                 <h2 class="font-display text-5xl md:text-7xl text-chrome mb-6 glitch-text" data-text="SPEAK_EXECUTE">SPEAK_EXECUTE</h2>
 
-                <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8 border-l-2 border-accent pl-4 text-left">
-                    Voice-controlled terminal for developers. Speak your commands naturally, watch them execute instantly. Multi-tab terminals, multiple AI providers, fully customizable.
+                <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8">
+                    Voice-controlled terminal for developers. Speak your commands naturally and watch them run. Multi-tab terminals, split panes, and your choice of AI provider.
                 </p>
 
                 <!-- Platform Download Buttons -->
@@ -364,7 +364,7 @@
                             <i data-lucide="mic" class="w-6 h-6 text-accent"></i>
                         </div>
                         <h4 class="font-display text-lg text-chrome mb-2">VOICE_RECOGNITION</h4>
-                        <p class="text-gray-500 text-sm">Multiple AI providers: Gemini, ElevenLabs, or local Whisper. Choose your engine.</p>
+                        <p class="text-gray-500 text-sm">Multiple AI providers: Gemini 2.0/2.5 Flash, ElevenLabs Scribe (real-time or batch), or fully offline with local Whisper or Parakeet. Choose your engine.</p>
                     </div>
 
                     <!-- Feature 2 -->
@@ -399,8 +399,8 @@
                         <div class="w-12 h-12 bg-iceDim border border-ice/30 flex items-center justify-center mb-4 clip-notch-tl">
                             <i data-lucide="terminal" class="w-6 h-6 text-ice"></i>
                         </div>
-                        <h4 class="font-display text-lg text-chrome mb-2">MULTI_TERMINAL</h4>
-                        <p class="text-gray-500 text-sm">Up to 4 panes with 5 layout presets. Split, zoom, and resize. Each pane runs its own shell.</p>
+                        <h4 class="font-display text-lg text-chrome mb-2">CLAUDE_CODE</h4>
+                        <p class="text-gray-500 text-sm">Detects Claude Code /voice mode and hands off cleanly: shows a [CC /voice] badge and pauses the built-in mic so the two never fight.</p>
                     </div>
 
                     <!-- Feature 6 -->
@@ -447,7 +447,7 @@
                         <div class="w-16 h-16 bg-signal text-black font-display font-bold text-2xl flex items-center justify-center shrink-0 clip-notch">03</div>
                         <div class="min-w-0 flex-1">
                             <h4 class="font-display text-xl text-chrome mb-2">EXECUTE</h4>
-                            <p class="text-gray-400 font-mono">Command is sent to your active terminal and executed. Results appear instantly. Hands stay on keyboard.</p>
+                            <p class="text-gray-400 font-mono">The command runs in your active terminal and the results come back in place. Hands stay on the keyboard.</p>
                         </div>
                     </div>
 
@@ -486,7 +486,7 @@
                                 <i data-lucide="apple" class="w-8 h-8 text-apple"></i>
                                 <div>
                                     <h4 class="font-display text-lg text-chrome">macOS</h4>
-                                    <p class="text-gray-500 text-xs">macOS 10.13+</p>
+                                    <p class="text-gray-500 text-xs">macOS 11+</p>
                                 </div>
                             </div>
                             <div class="flex gap-2">
@@ -507,7 +507,7 @@
                                 STAR ON GITHUB
                             </span>
                         </a>
-                        <a href="https://github.com/jamditis/audiobash/blob/master/docs/USER_MANUAL.md" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-accent hover:text-accent transition-all">
+                        <a href="manual.html" class="px-8 py-4 border border-white/20 text-chrome font-display font-bold text-lg tracking-wider hover:border-accent hover:text-accent transition-all">
                             <span class="flex items-center gap-2">
                                 <i data-lucide="book-open" class="w-5 h-5"></i>
                                 USER MANUAL

--- a/docs/index.html
+++ b/docs/index.html
@@ -364,7 +364,7 @@
                             <i data-lucide="mic" class="w-6 h-6 text-accent"></i>
                         </div>
                         <h4 class="font-display text-lg text-chrome mb-2">VOICE_RECOGNITION</h4>
-                        <p class="text-gray-500 text-sm">Multiple AI providers: Gemini 2.0/2.5 Flash, ElevenLabs Scribe (real-time or batch), or fully offline with local Whisper or Parakeet. Choose your engine.</p>
+                        <p class="text-gray-500 text-sm">Multiple AI providers: Gemini 2.0/2.5 Flash, ElevenLabs Scribe (real-time or batch), or fully offline with bundled local Whisper. Parakeet is also supported if you run your own NVIDIA GPU server. Choose your engine.</p>
                     </div>
 
                     <!-- Feature 2 -->
@@ -486,7 +486,7 @@
                                 <i data-lucide="apple" class="w-8 h-8 text-apple"></i>
                                 <div>
                                     <h4 class="font-display text-lg text-chrome">macOS</h4>
-                                    <p class="text-gray-500 text-xs">macOS 11+</p>
+                                    <p class="text-gray-500 text-xs">macOS 12+</p>
                                 </div>
                             </div>
                             <div class="flex gap-2">

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AudioBash for macOS - Now Available</title>
-    <meta name="description" content="AudioBash v2.1 brings ElevenLabs Scribe v2 real-time transcription! Voice-controlled terminal for developers, on Apple Silicon and Intel Macs.">
+    <meta name="description" content="AudioBash is a voice-controlled terminal for developers, with native Apple Silicon and Intel Mac builds. Speak commands, execute instantly.">
 
     <!-- Open Graph -->
     <meta property="og:title" content="AudioBash for macOS - Now Available">
@@ -215,7 +215,7 @@
             <!-- Badge -->
             <div class="inline-flex items-center gap-2 px-4 py-2 bg-appleDim border border-apple/30 text-apple text-sm font-mono mb-8">
                 <span class="w-2 h-2 bg-apple rounded-full animate-pulse-slow"></span>
-                <span data-version="v{version}">v2.4.0</span> — Electron 39 + Apple Silicon fix
+                <span data-version="v{version}">v3.2.0</span> — customizable pane colors
             </div>
 
             <!-- Apple Icon -->
@@ -290,7 +290,7 @@
                         <i data-lucide="keyboard" class="w-6 h-6 text-apple"></i>
                     </div>
                     <h3 class="font-display text-lg text-chrome mb-2">Mac shortcuts</h3>
-                    <p class="text-gray-400 text-sm"><code>Option+S</code> for push-to-talk. All 14 global shortcuts work with the Option key.</p>
+                    <p class="text-gray-400 text-sm"><code>Option+S</code> for push-to-talk. Every global shortcut works with the Option key.</p>
                 </div>
             </div>
         </section>
@@ -338,7 +338,7 @@
                         <div class="w-10 h-10 bg-signal text-black font-display font-bold flex items-center justify-center shrink-0">3</div>
                         <div class="min-w-0 flex-1">
                             <h4 class="font-display text-chrome text-lg mb-2">Bypass Gatekeeper (important!)</h4>
-                            <p class="text-gray-400 text-sm mb-3">AudioBash isn't yet signed with an Apple Developer certificate (code signing infrastructure is ready, pending activation). Bypass Gatekeeper on first launch:</p>
+                            <p class="text-gray-400 text-sm mb-3">AudioBash isn't code-signed yet. The signing infrastructure is in the repo and signed builds are planned; until then, bypass Gatekeeper on first launch:</p>
 
                             <div class="bg-void border border-signal/30 p-4 mb-3">
                                 <p class="text-signal font-display text-sm mb-2">Option A: Right-click method (easiest)</p>
@@ -448,12 +448,12 @@
                         <p class="text-gray-500 mt-1">Cycle layouts</p>
                     </div>
                     <div class="text-center">
-                        <code class="text-apple">Cmd+T</code>
-                        <p class="text-gray-500 mt-1">New tab</p>
+                        <code class="text-apple">Option+1-4</code>
+                        <p class="text-gray-500 mt-1">Switch tab</p>
                     </div>
                     <div class="text-center">
-                        <code class="text-apple">Cmd+W</code>
-                        <p class="text-gray-500 mt-1">Close tab</p>
+                        <code class="text-apple">Option+W</code>
+                        <p class="text-gray-500 mt-1">Close pane</p>
                     </div>
                 </div>
             </div>
@@ -495,7 +495,7 @@
                     <ul class="text-gray-400 text-sm space-y-2">
                         <li>• Push-to-talk with global hotkey</li>
                         <li>• ElevenLabs Scribe v2 real-time (~150ms)</li>
-                        <li>• Multiple AI providers: Gemini, ElevenLabs, local Whisper</li>
+                        <li>• Multiple AI providers: Gemini, ElevenLabs, and local Whisper or Parakeet (offline)</li>
                         <li>• Local Whisper for offline transcription (no API key)</li>
                         <li>• Raw mode (verbatim) or Agent mode (AI interprets intent)</li>
                         <li>• Custom vocabulary for technical terms</li>
@@ -537,9 +537,10 @@
                     <ul class="text-gray-400 text-sm space-y-2">
                         <li>• CLI notification chimes (approval prompts, etc.)</li>
                         <li>• System tray / menu bar integration</li>
-                        <li>• 5 themes: Void, Cyberpunk, Matrix, Amber, Ice</li>
+                        <li>• 5 themes: Void, Hacker, Amber, Midnight, Solarized</li>
                         <li>• CRT scanline effect (optional)</li>
                         <li>• Multi-terminal panes with 5 layout presets</li>
+                        <li>• Customizable pane colors with activity fade (8-color palette)</li>
                     </ul>
                 </div>
             </div>
@@ -582,7 +583,7 @@
                         <span class="px-2 py-1 bg-yellow-500/20 text-yellow-500 text-xs font-mono shrink-0">ALL</span>
                         <div>
                             <h4 class="text-chrome text-sm mb-1">Long recordings may delay</h4>
-                            <p class="text-gray-500 text-xs">Recordings over 30 seconds may take longer to transcribe. Keep recordings short for best experience.</p>
+                            <p class="text-gray-500 text-xs">Recordings more than 30 seconds may take longer to transcribe. Keep recordings short for best experience.</p>
                         </div>
                     </div>
                 </div>

--- a/docs/macos.html
+++ b/docs/macos.html
@@ -463,7 +463,7 @@
         <section class="mb-20 section-animate">
             <div class="text-center mb-10">
                 <h2 class="font-display text-3xl text-chrome mb-2">FULL_FEATURES</h2>
-                <p class="text-gray-500" data-version="Everything included in v{version}">Everything included in v2.3.5</p>
+                <p class="text-gray-500" data-version="Everything included in v{version}">Everything included in v3.2.0</p>
             </div>
 
             <!-- Feature Screenshots Gallery -->
@@ -495,7 +495,7 @@
                     <ul class="text-gray-400 text-sm space-y-2">
                         <li>• Push-to-talk with global hotkey</li>
                         <li>• ElevenLabs Scribe v2 real-time (~150ms)</li>
-                        <li>• Multiple AI providers: Gemini, ElevenLabs, and local Whisper or Parakeet (offline)</li>
+                        <li>• Multiple AI providers: Gemini, ElevenLabs, and local Whisper (offline)</li>
                         <li>• Local Whisper for offline transcription (no API key)</li>
                         <li>• Raw mode (verbatim) or Agent mode (AI interprets intent)</li>
                         <li>• Custom vocabulary for technical terms</li>
@@ -622,7 +622,7 @@
     <footer class="border-t border-white/10 py-8 px-6 relative z-10">
         <div class="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
             <div class="text-[10px] text-gray-600 font-mono">
-                <span data-version="AUDIOBASH v{version} // macOS EDITION // MIT LICENSE">AUDIOBASH v2.3.5 // macOS EDITION // MIT LICENSE</span>
+                <span data-version="AUDIOBASH v{version} // macOS EDITION // MIT LICENSE">AUDIOBASH v3.2.0 // macOS EDITION // MIT LICENSE</span>
             </div>
             <div class="flex items-center gap-4 text-gray-500 text-sm">
                 <a href="index.html" class="hover:text-apple transition-colors">Home</a>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Manual // AUDIOBASH</title>
-    <meta name="description" content="Complete user guide for AudioBash - Voice-controlled terminal for developers. Installation, setup, and usage instructions for Windows and macOS.">
+    <meta name="description" content="Complete user guide for AudioBash - Voice-controlled terminal for developers. Installation, setup, and usage instructions for Windows, macOS, and Linux.">
 
     <!-- Open Graph -->
     <meta property="og:title" content="AudioBash User Manual">
-    <meta property="og:description" content="Complete guide to installing and using AudioBash on Windows and macOS.">
+    <meta property="og:description" content="Complete guide to installing and using AudioBash on Windows, macOS, and Linux.">
     <meta property="og:type" content="website">
 
     <!-- Favicon -->
@@ -205,6 +205,7 @@
                     <a href="#installation" class="toc-link block py-1 pl-3 border-l-2 border-white/10 text-gray-400 transition-colors">Installation</a>
                     <a href="#windows" class="toc-link block py-1 pl-6 border-l-2 border-white/10 text-gray-500 transition-colors text-xs">Windows</a>
                     <a href="#macos" class="toc-link block py-1 pl-6 border-l-2 border-white/10 text-gray-500 transition-colors text-xs">macOS</a>
+                    <a href="#linux" class="toc-link block py-1 pl-6 border-l-2 border-white/10 text-gray-500 transition-colors text-xs">Linux</a>
                     <a href="#setup" class="toc-link block py-1 pl-3 border-l-2 border-white/10 text-gray-400 transition-colors">First-time setup</a>
                     <a href="#usage" class="toc-link block py-1 pl-3 border-l-2 border-white/10 text-gray-400 transition-colors">Using AudioBash</a>
                     <a href="#shortcuts" class="toc-link block py-1 pl-6 border-l-2 border-white/10 text-gray-500 transition-colors text-xs">Keyboard shortcuts</a>
@@ -225,10 +226,10 @@
             <div class="mb-12">
                 <div class="inline-flex items-center gap-2 px-3 py-1 bg-accent/10 border border-accent/30 text-accent text-xs font-mono mb-4">
                     <span class="w-2 h-2 bg-accent rounded-full"></span>
-                    <span data-version="v{version}">v2.4.1</span>
+                    <span data-version="v{version}">v3.2.0</span>
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">USER_MANUAL</h1>
-                <p class="text-gray-400 text-lg">Complete guide to installing and using AudioBash on Windows and macOS.</p>
+                <p class="text-gray-400 text-lg">Complete guide to installing and using AudioBash on Windows, macOS, and Linux.</p>
 
                 <!-- Hero Screenshot -->
                 <div class="mt-8">
@@ -246,7 +247,7 @@
                         INTRODUCTION
                     </h2>
                     <div class="space-y-4">
-                        <p>AudioBash is a voice-controlled terminal application designed to work seamlessly with Claude Code. Instead of typing commands, you can speak them directly into your terminal. The application transcribes your voice input using AI-powered speech recognition and executes commands in a real terminal environment.</p>
+                        <p>AudioBash is a voice-controlled terminal built to work with Claude Code. Instead of typing commands, you can speak them directly into your terminal. The application transcribes your voice input using AI-powered speech recognition and executes commands in a real terminal environment.</p>
 
                         <div class="bg-panel border border-white/10 p-6 mt-6">
                             <h4 class="font-display text-chrome mb-4">Key features</h4>
@@ -257,7 +258,7 @@
                                 </li>
                                 <li class="flex items-start gap-2">
                                     <i data-lucide="layers" class="w-4 h-4 text-ice mt-1 shrink-0"></i>
-                                    <span><strong class="text-chrome">Multi-provider transcription</strong> - Gemini, ElevenLabs, or local Whisper</span>
+                                    <span><strong class="text-chrome">Multi-provider transcription</strong> - Gemini, ElevenLabs, or local Whisper/Parakeet</span>
                                 </li>
                                 <li class="flex items-start gap-2">
                                     <i data-lucide="terminal" class="w-4 h-4 text-signal mt-1 shrink-0"></i>
@@ -269,7 +270,7 @@
                                 </li>
                                 <li class="flex items-start gap-2">
                                     <i data-lucide="monitor" class="w-4 h-4 text-ice mt-1 shrink-0"></i>
-                                    <span><strong class="text-chrome">Cross-platform</strong> - Works on Windows 10/11 and macOS (Intel & Apple Silicon)</span>
+                                    <span><strong class="text-chrome">Cross-platform</strong> - Works on Windows 10/11, macOS (Intel & Apple Silicon), and Linux</span>
                                 </li>
                             </ul>
                         </div>
@@ -375,7 +376,7 @@
                                 <span class="w-6 h-6 bg-apple text-black font-display font-bold text-sm flex items-center justify-center shrink-0">3</span>
                                 <div>
                                     <strong class="text-chrome">First launch (important!)</strong>
-                                    <p class="text-sm mt-1">AudioBash is not yet signed with an Apple Developer certificate (pending). You must bypass Gatekeeper on first launch:</p>
+                                    <p class="text-sm mt-1">AudioBash isn't code-signed yet. The signing infrastructure is in the repo and signed builds are planned; until then, you must bypass Gatekeeper on first launch:</p>
                                     <div class="bg-void border border-white/10 p-4 mt-3 text-sm">
                                         <p class="text-chrome font-display mb-2">Method 1 - Right-click (recommended)</p>
                                         <p>Open Finder → Applications → <strong>Right-click</strong> AudioBash.app → Select "Open" → Click "Open" in the dialog</p>
@@ -395,6 +396,68 @@
                                         <li><strong>Microphone access:</strong> System Settings → Privacy & Security → Microphone</li>
                                         <li><strong>Accessibility access:</strong> System Settings → Privacy & Security → Accessibility (required for global hotkeys)</li>
                                     </ul>
+                                </div>
+                            </li>
+                        </ol>
+                    </div>
+
+                    <!-- Linux -->
+                    <div id="linux" class="mt-10">
+                        <h3 class="font-display text-xl text-chrome mb-4 flex items-center gap-2">
+                            <i data-lucide="terminal" class="w-5 h-5"></i>
+                            Linux installation
+                        </h3>
+
+                        <div class="bg-panel border border-white/10 p-6 mb-6">
+                            <h4 class="font-display text-chrome mb-3">System requirements</h4>
+                            <ul class="text-gray-400 space-y-1 text-sm">
+                                <li>A 64-bit Linux distribution (AppImage and .deb supported)</li>
+                                <li>Node.js 20 or newer and npm</li>
+                                <li>Build tools for native modules (build-essential and python3, to compile node-pty)</li>
+                                <li>4GB RAM minimum (8GB recommended)</li>
+                                <li>Microphone for voice input</li>
+                            </ul>
+                        </div>
+
+                        <p class="text-gray-400 text-sm mb-4">Prebuilt Linux binaries aren't posted on the releases page yet, so build from source. The repo ships an electron-builder Linux target that produces an AppImage and a .deb.</p>
+
+                        <h4 class="font-display text-chrome mb-3">Build steps</h4>
+                        <ol class="space-y-4 text-gray-400">
+                            <li class="flex gap-3">
+                                <span class="w-6 h-6 bg-chrome text-black font-display font-bold text-sm flex items-center justify-center shrink-0">1</span>
+                                <div>
+                                    <strong class="text-chrome">Clone the repository</strong>
+                                    <div class="bg-void border border-white/10 p-4 mt-2 text-sm">
+                                        <pre><code>git clone https://github.com/jamditis/audiobash.git
+cd audiobash</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="flex gap-3">
+                                <span class="w-6 h-6 bg-chrome text-black font-display font-bold text-sm flex items-center justify-center shrink-0">2</span>
+                                <div>
+                                    <strong class="text-chrome">Install dependencies</strong>
+                                    <p class="text-sm mt-1">This compiles node-pty for your architecture.</p>
+                                    <div class="bg-void border border-white/10 p-4 mt-2 text-sm">
+                                        <pre><code>npm install</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="flex gap-3">
+                                <span class="w-6 h-6 bg-chrome text-black font-display font-bold text-sm flex items-center justify-center shrink-0">3</span>
+                                <div>
+                                    <strong class="text-chrome">Build the Linux package</strong>
+                                    <p class="text-sm mt-1">Produces an AppImage and a .deb in <code>dist/</code>. To run without packaging, use <code>npm run electron:dev</code>.</p>
+                                    <div class="bg-void border border-white/10 p-4 mt-2 text-sm">
+                                        <pre><code>npm run electron:build:linux</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="flex gap-3">
+                                <span class="w-6 h-6 bg-chrome text-black font-display font-bold text-sm flex items-center justify-center shrink-0">4</span>
+                                <div>
+                                    <strong class="text-chrome">Run it</strong>
+                                    <p class="text-sm mt-1">Make the AppImage executable with <code>chmod +x</code> and launch it, or install the .deb with <code>sudo dpkg -i</code>. Grant microphone access when prompted.</p>
                                 </div>
                             </li>
                         </ol>
@@ -492,6 +555,11 @@
                                     <td><code>Option+A</code></td>
                                 </tr>
                                 <tr>
+                                    <td>Resend last transcription</td>
+                                    <td><code>Alt+R</code></td>
+                                    <td><code>Option+R</code></td>
+                                </tr>
+                                <tr>
                                     <td>Toggle raw/agent mode</td>
                                     <td><code>Alt+M</code></td>
                                     <td><code>Option+M</code></td>
@@ -507,22 +575,83 @@
                                     <td><code>Option+C</code></td>
                                 </tr>
                                 <tr>
-                                    <td>Cycle layouts</td>
+                                    <td>Increase font size</td>
+                                    <td><code>Ctrl+=</code></td>
+                                    <td><code>Ctrl+=</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Decrease font size</td>
+                                    <td><code>Ctrl+-</code></td>
+                                    <td><code>Ctrl+-</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Reset font size</td>
+                                    <td><code>Ctrl+0</code></td>
+                                    <td><code>Ctrl+0</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Switch to tab 1-4</td>
+                                    <td><code>Alt+1</code> - <code>Alt+4</code></td>
+                                    <td><code>Option+1</code> - <code>Option+4</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Bookmark current directory</td>
+                                    <td><code>Alt+B</code></td>
+                                    <td><code>Option+B</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Cycle layout preset</td>
                                     <td><code>Alt+L</code></td>
                                     <td><code>Option+L</code></td>
                                 </tr>
                                 <tr>
-                                    <td>New tab</td>
-                                    <td><code>Ctrl+T</code></td>
-                                    <td><code>Cmd+T</code></td>
+                                    <td>Split pane horizontal</td>
+                                    <td><code>Alt+-</code></td>
+                                    <td><code>Option+-</code></td>
                                 </tr>
                                 <tr>
-                                    <td>Close tab</td>
-                                    <td><code>Ctrl+W</code></td>
-                                    <td><code>Cmd+W</code></td>
+                                    <td>Split pane vertical</td>
+                                    <td><code>Alt+\</code></td>
+                                    <td><code>Option+\</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Close pane</td>
+                                    <td><code>Alt+W</code></td>
+                                    <td><code>Option+W</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Zoom/unzoom pane</td>
+                                    <td><code>Alt+Z</code></td>
+                                    <td><code>Option+Z</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Focus next pane</td>
+                                    <td><code>Alt+Right</code></td>
+                                    <td><code>Option+Right</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Focus previous pane</td>
+                                    <td><code>Alt+Left</code></td>
+                                    <td><code>Option+Left</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Resize pane</td>
+                                    <td><code>Alt+Shift+Arrow</code></td>
+                                    <td><code>Option+Shift+Arrow</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Toggle preview pane</td>
+                                    <td><code>Alt+P</code></td>
+                                    <td><code>Option+P</code></td>
+                                </tr>
+                                <tr>
+                                    <td>Capture preview screenshot</td>
+                                    <td><code>Alt+Shift+P</code></td>
+                                    <td><code>Option+Shift+P</code></td>
                                 </tr>
                             </tbody>
                         </table>
+                        <p class="text-gray-500 text-sm mt-4">New tab and close tab have no keyboard shortcut - use the <code>+</code> button to add a tab and the <code>×</code> on a tab to close it.</p>
                     </div>
 
                     <!-- Voice Recording -->
@@ -595,9 +724,9 @@
                         <h3 class="font-display text-xl text-chrome mb-4">Multi-tab interface</h3>
                         <p class="text-gray-400 mb-4">AudioBash supports multiple terminal tabs:</p>
                         <ul class="text-gray-400 space-y-2">
-                            <li><strong class="text-chrome">New tab:</strong> Click the <code>+</code> button or press <code>Ctrl/Cmd+T</code></li>
-                            <li><strong class="text-chrome">Switch tabs:</strong> Click on tabs or use <code>Ctrl+Tab</code></li>
-                            <li><strong class="text-chrome">Close tab:</strong> Click the <code>×</code> on the tab or press <code>Ctrl/Cmd+W</code></li>
+                            <li><strong class="text-chrome">New tab:</strong> Click the <code>+</code> button</li>
+                            <li><strong class="text-chrome">Switch tabs:</strong> Click a tab or press <code>Alt+1</code>-<code>Alt+4</code> (<code>Option+1</code>-<code>Option+4</code> on Mac)</li>
+                            <li><strong class="text-chrome">Close tab:</strong> Click the <code>×</code> on the tab</li>
                             <li><strong class="text-chrome">Rename tab:</strong> Double-click the tab title</li>
                         </ul>
                         <p class="text-gray-500 text-sm mt-4">Each tab maintains its own working directory, command history, and shell session.</p>
@@ -656,7 +785,7 @@
                                     </tr>
                                     <tr>
                                         <td>ElevenLabs API key</td>
-                                        <td>Real-time streaming and text-to-speech</td>
+                                        <td>Real-time and batch speech-to-text (Scribe)</td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -666,8 +795,11 @@
                             <h4 class="font-display text-chrome mb-3">Transcription providers</h4>
                             <ul class="text-gray-400 space-y-1 text-sm">
                                 <li><strong class="text-accent">Gemini 2.0 Flash</strong> - Google's fast, accurate model (recommended, free tier)</li>
+                                <li><strong class="text-accent">Gemini 2.5 Flash</strong> - Latest Gemini with audio support</li>
+                                <li><strong class="text-ice">ElevenLabs Scribe</strong> - High-quality batch speech-to-text</li>
                                 <li><strong class="text-ice">ElevenLabs Scribe v2</strong> - Real-time WebSocket streaming (~150ms latency)</li>
-                                <li><strong>Local Whisper</strong> - Offline transcription, no API key required</li>
+                                <li><strong>Parakeet (local)</strong> - Free offline transcription, requires an NVIDIA GPU</li>
+                                <li><strong>Local Whisper</strong> - Offline transcription via whisper.cpp (small.en, 466 MB), no API key required</li>
                             </ul>
                             <p class="text-gray-500 text-sm mt-3">Click the model name in the voice overlay to cycle between providers without opening settings.</p>
                         </div>
@@ -692,7 +824,7 @@
                             <div class="space-y-4">
                                 <div class="bg-panel border border-white/10 p-4">
                                     <h4 class="text-chrome mb-2">"Windows protected your PC" SmartScreen warning</h4>
-                                    <p class="text-gray-400 text-sm">Click "More info" → "Run anyway". This appears because the app isn't signed with an expensive certificate.</p>
+                                    <p class="text-gray-400 text-sm">Click "More info" then "Run anyway". This appears because the Windows build is not yet code-signed.</p>
                                 </div>
                                 <div class="bg-panel border border-white/10 p-4">
                                     <h4 class="text-chrome mb-2">Global shortcuts not working</h4>
@@ -759,7 +891,7 @@
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
                             <h4 class="text-chrome mb-2">Can I use AudioBash with Claude Code CLI?</h4>
-                            <p class="text-gray-400 text-sm">Absolutely! That's exactly what it's designed for. Just type <code>claude</code> in the terminal to start Claude Code, then use voice commands to interact with it.</p>
+                            <p class="text-gray-400 text-sm">Yes - that's what it's designed for. Type <code>claude</code> in the terminal to start Claude Code, then use voice commands to interact with it.</p>
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
                             <h4 class="text-chrome mb-2">Where are settings stored?</h4>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -344,7 +344,7 @@
                         <div class="bg-panel border border-apple/20 p-6 mb-6">
                             <h4 class="font-display text-chrome mb-3">System requirements</h4>
                             <ul class="text-gray-400 space-y-1 text-sm">
-                                <li>macOS 11 (Big Sur) or later</li>
+                                <li>macOS 12 (Monterey) or later</li>
                                 <li>Apple Silicon (M1/M2/M3/M4) or Intel processor</li>
                                 <li>4GB RAM minimum (8GB recommended)</li>
                                 <li>200MB disk space</li>
@@ -652,6 +652,7 @@ cd audiobash</code></pre>
                             </tbody>
                         </table>
                         <p class="text-gray-500 text-sm mt-4">New tab and close tab have no keyboard shortcut - use the <code>+</code> button to add a tab and the <code>×</code> on a tab to close it.</p>
+                        <p class="text-gray-500 text-sm mt-2"><strong class="text-chrome">Linux note:</strong> the global Alt shortcuts above register under X11 but may not fire under Wayland. If a shortcut doesn't respond on a Wayland session, switch to an X11 session or use the on-screen controls instead.</p>
                     </div>
 
                     <!-- Voice Recording -->

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -539,7 +539,7 @@ cd audiobash</code></pre>
                             <thead>
                                 <tr>
                                     <th>Action</th>
-                                    <th>Windows</th>
+                                    <th>Windows / Linux</th>
                                     <th>macOS</th>
                                 </tr>
                             </thead>
@@ -887,7 +887,7 @@ cd audiobash</code></pre>
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
                             <h4 class="text-chrome mb-2">Can I use AudioBash with any shell?</h4>
-                            <p class="text-gray-400 text-sm">Yes. On Windows, it defaults to PowerShell. On macOS, it uses your default shell (usually zsh or bash). You can start any shell by typing its name.</p>
+                            <p class="text-gray-400 text-sm">Yes. On Windows, it defaults to PowerShell. On macOS and Linux, it uses your default shell (your <code>$SHELL</code>, usually zsh on macOS and bash on Linux). You can start any shell by typing its name.</p>
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
                             <h4 class="text-chrome mb-2">Can I use AudioBash with Claude Code CLI?</h4>
@@ -897,7 +897,8 @@ cd audiobash</code></pre>
                             <h4 class="text-chrome mb-2">Where are settings stored?</h4>
                             <p class="text-gray-400 text-sm">
                                 <strong>Windows:</strong> <code>%APPDATA%\AudioBash\</code><br>
-                                <strong>macOS:</strong> <code>~/Library/Application Support/AudioBash/</code>
+                                <strong>macOS:</strong> <code>~/Library/Application Support/AudioBash/</code><br>
+                                <strong>Linux:</strong> <code>~/.config/AudioBash/</code>
                             </p>
                         </div>
                         <div class="bg-panel border border-white/10 p-4">
@@ -916,7 +917,7 @@ cd audiobash</code></pre>
             <!-- FOOTER -->
             <div class="mt-16 pt-8 border-t border-white/10">
                 <div class="flex flex-col md:flex-row items-center justify-between gap-4 text-gray-500 text-sm">
-                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v2.4.1 - Voice-controlled terminal for Claude Code</div>
+                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v3.2.0 - Voice-controlled terminal for Claude Code</div>
                     <div class="flex items-center gap-4">
                         <a href="about.html" class="hover:text-accent transition-colors">About</a>
                         <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">GitHub</a>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -798,7 +798,7 @@ cd audiobash</code></pre>
                                 <li><strong class="text-accent">Gemini 2.5 Flash</strong> - Latest Gemini with audio support</li>
                                 <li><strong class="text-ice">ElevenLabs Scribe</strong> - High-quality batch speech-to-text</li>
                                 <li><strong class="text-ice">ElevenLabs Scribe v2</strong> - Real-time WebSocket streaming (~150ms latency)</li>
-                                <li><strong>Parakeet (local)</strong> - Free offline transcription, requires an NVIDIA GPU</li>
+                                <li><strong>Parakeet (local)</strong> - Offline transcription on an NVIDIA GPU. Advanced: it sends audio to a separate Parakeet server you run yourself at <code>localhost:8003</code>. Unlike Whisper, no server is bundled, so you must start one before selecting this provider.</li>
                                 <li><strong>Local Whisper</strong> - Offline transcription via whisper.cpp (small.en, 466 MB), no API key required</li>
                             </ul>
                             <p class="text-gray-500 text-sm mt-3">Click the model name in the voice overlay to cycle between providers without opening settings.</p>


### PR DESCRIPTION
Refreshes the audiobash.app documentation so it matches the current 3.2.0 app. Content and copy only - no app code and no version bump (the bump stays with the v3.3.0 release).

## What changed

### Keyboard shortcuts (manual.html)
Rebuilt the shortcut table against `DEFAULT_SHORTCUTS` and the renderer `before-input-event` handlers in `electron/main.cjs`:
- Font zoom is `Ctrl+=/-/0` on every platform (the handler checks `input.control`, not Cmd).
- Pane resize is `Alt+Shift+Arrow` (`Option+Shift+Arrow` on Mac).
- Tab create/close have no hotkey - documented the `+` button and the `x` on a tab instead of the phantom `Ctrl+T`/`Cmd+W`.
- Added the missing rows (resend last, bookmark, split/zoom/focus panes, toggle preview, capture screenshot).

### Transcription providers (manual.html, index.html, macos.html)
- The ElevenLabs key is speech-to-text (Scribe), not text-to-speech.
- Listed the real provider set: Gemini 2.0/2.5 Flash, ElevenLabs Scribe and Scribe v2 (real-time ~150ms), local Whisper (whisper.cpp small.en), and Parakeet (local, NVIDIA GPU).

### Linux (manual.html)
Advertised Linux as a supported build-from-source platform - the repo ships an electron-builder Linux target (AppImage + deb). No download buttons, since no Linux binary is published to a release yet (the release job only attaches Windows and macOS artifacts). Build steps and a TOC entry added.

### Accuracy and copy
- Code-signing wording is neutral with no committed timeline.
- macOS floor corrected to 11+ (Electron 39).
- Theme names corrected to Void, Hacker, Amber, Midnight, Solarized.
- De-staled hardcoded version fallbacks to 3.2.0 (the `data-version` templates already render the live version via `version.js`; only the no-JS fallback text was stale).
- Dropped the hero sliver-border styling and a few banned words from the hero/intro copy.

## Scope notes
- `docs/` only. No source changes.
- This serves the live site (GitHub Pages), so it lands as a PR rather than a direct push.
- Deferred to the v3.3.0 release: version bump across the docs, README signing wording, and adding a real Linux download button once Linux binaries ship.