### PR TITLE
v3.3.0: Linux builds, hardened transcription, Wayland shortcuts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
       build_linux:
         description: 'Build for Linux'
         required: false
-        default: false
+        default: true
         type: boolean
 
 jobs:
@@ -81,7 +81,7 @@ jobs:
           retention-days: 30
 
   build-linux:
-    if: inputs.build_linux == true
+    if: github.event_name == 'push' || inputs.build_linux
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -110,7 +110,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-mac, build-windows]
+    needs: [build-mac, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -133,4 +133,6 @@ jobs:
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/*.exe
+            artifacts/**/*.AppImage
+            artifacts/**/*.deb
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A voice-controlled terminal for developers. Speak commands, execute them instant
 ## Features
 
 - **Voice-to-terminal** - Speak naturally and have your words transcribed directly into the terminal
+- **Cross-platform** - Native builds for Windows, macOS (Intel & Apple Silicon), and Linux (AppImage & .deb)
 - **Tmux-style pane system** - Binary tree pane architecture with split horizontal (Alt+-) and vertical (Alt+\), drag dividers, double-click to equalize, 5 preset layouts
 - **Customizable pane colors** - 8-color palette (Emerald, Cobalt, Crimson, Violet, Cyan, Amber, Rose, Acid) with activity-based fade: full color → fading → dim → gray as terminals go idle. Error exits always red. Colors persist across restarts
 - **Pane keyboard navigation** - Alt+Arrow to move focus, Alt+1-4 for direct focus, Alt+Shift+Arrow to resize, Alt+Z to zoom/unzoom
@@ -31,11 +32,11 @@ A voice-controlled terminal for developers. Speak commands, execute them instant
 - **Window persistence** - Window position and size saved across sessions
 - **Multi-tab support** - Run up to 4 terminal sessions simultaneously
 - **Quick directory navigation** - Jump to recent or favorite folders with one click
-- **Multiple AI providers** - Gemini 2.0/2.5 Flash, OpenAI Whisper, Claude, or ElevenLabs
+- **Multiple AI providers** - Gemini 2.0/2.5 Flash, ElevenLabs Scribe (real-time or batch), or fully offline with bundled local Whisper (plus Parakeet, if you run your own NVIDIA GPU server)
 - **Auto-copy** - Selected text is automatically copied to clipboard
 - **Always-on-top mode** - Pin the voice panel while you work
 - **System tray** - Runs quietly in background, accessible via global shortcuts
-- **Extensive keyboard shortcuts** - 16 customizable shortcuts for power users
+- **Extensive keyboard shortcuts** - 20 customizable shortcuts for power users
 - **Preview pane** - Embedded web preview for localhost dev servers, HTML, images, and markdown
 - **Screenshot capture** - Take screenshots of the preview pane (saves to current working directory)
 - **Auto-refresh** - File watcher automatically refreshes preview when source files change
@@ -52,7 +53,7 @@ Download the latest `.exe` installer from [Releases](https://github.com/jamditis
 
 ### macOS
 
-> **Signed builds coming soon.** The current DMG builds are unsigned and may not launch on Apple Silicon. Build from source for the most reliable experience. See [macOS code signing](#macos-code-signing-coming-soon).
+> **The DMG builds aren't signed yet.** Downloaded DMGs are unsigned and may not launch on Apple Silicon without a Gatekeeper bypass. Building from source is the most reliable option until signed builds ship. See [macOS code signing](#macos-code-signing-coming-soon).
 
 ```bash
 git clone https://github.com/jamditis/audiobash.git
@@ -63,6 +64,21 @@ npm run electron:dev                  # Run in dev mode
 npm run electron:build:mac:arm64      # Build DMG for Apple Silicon (M1/M2/M3/M4)
 npm run electron:build:mac:x64        # Build DMG for Intel Macs
 ```
+
+### Linux
+
+Download the latest `.AppImage` or `.deb` from [Releases](https://github.com/jamditis/audiobash/releases).
+
+```bash
+# AppImage (portable, runs on most distributions)
+chmod +x AudioBash-*.AppImage
+./AudioBash-*.AppImage
+
+# Debian / Ubuntu
+sudo dpkg -i AudioBash-*.deb
+```
+
+Global shortcuts use the desktop's GlobalShortcuts portal on Wayland and fall back to X11.
 
 ### Build from source (any platform)
 
@@ -140,7 +156,7 @@ Open Settings (gear icon in title bar) to configure:
 
 The macOS DMG builds are currently **unsigned**, which means Gatekeeper blocks them on Apple Silicon Macs and may cause crashes even after using `xattr -cr` or right-click → Open. We're aware this is a bad experience.
 
-**We've enrolled in the Apple Developer Program** and are waiting for activation (can take up to 48 hours). Once active, all macOS builds will be:
+**Code signing and notarization are planned.** The signing infrastructure (entitlements and the notarization hook) is already in the repo. Once a Developer ID certificate is active, macOS builds will be:
 
 - **Signed** with a Developer ID Application certificate
 - **Notarized** by Apple — Gatekeeper will trust the app on first launch

--- a/docs/index.html
+++ b/docs/index.html
@@ -344,7 +344,7 @@
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #3399ff;">///</div>
                         <h4 class="font-display text-chrome mb-1">Hardened transcription</h4>
-                        <p class="text-gray-500 text-sm">Cloud transcription now runs in the main process. API keys and provider SDKs never touch the browser layer.</p>
+                        <p class="text-gray-500 text-sm">Cloud transcription requests now run in the main process instead of the renderer.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ff3333;">///</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -344,7 +344,7 @@
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #3399ff;">///</div>
                         <h4 class="font-display text-chrome mb-1">Hardened transcription</h4>
-                        <p class="text-gray-500 text-sm">Cloud transcription requests now run in the main process instead of the renderer.</p>
+                        <p class="text-gray-500 text-sm">Batch cloud transcription requests now run in the main process instead of the renderer.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ff3333;">///</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,8 @@
                         iceDim: 'rgba(0, 240, 255, 0.1)',
                         apple: '#a3aaae',
                         appleDim: 'rgba(163, 170, 174, 0.1)',
+                        linux: '#ccff00',
+                        linuxDim: 'rgba(204, 255, 0, 0.1)',
                     },
                     backgroundImage: {
                         'grid-pattern': "linear-gradient(to right, #222 1px, transparent 1px), linear-gradient(to bottom, #222 1px, transparent 1px)",
@@ -207,7 +209,7 @@
                 <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                 <div>
                     <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
-                    <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v3.2.0 // VOICE_TERMINAL</p>
+                    <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v3.3.0 // VOICE_TERMINAL</p>
                 </div>
             </div>
             <div class="flex items-center gap-4">
@@ -239,7 +241,7 @@
                 <!-- NEW: Version Badge -->
                 <a href="latest.html" class="inline-flex items-center gap-2 px-4 py-2 bg-accent/10 border border-accent/30 text-accent text-sm font-mono mb-6 hover:bg-accent/20 transition-colors">
                     <span class="w-2 h-2 bg-accent rounded-full animate-pulse"></span>
-                    <span data-version="v{version}">v3.2.0</span> — Customizable pane colors, activity fade, exit-closes-pane
+                    <span data-version="v{version}">v3.3.0</span> — Linux builds, hardened transcription, Wayland shortcuts
                     <i data-lucide="arrow-right" class="w-4 h-4"></i>
                 </a>
 
@@ -269,6 +271,12 @@
                         <span class="flex items-center gap-2">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
+                        </span>
+                    </a>
+                    <a href="#" data-download="linux-appimage" class="px-6 py-3 border border-white/20 text-chrome font-display font-bold text-sm tracking-wider hover:border-linux hover:text-linux transition-all">
+                        <span class="flex items-center gap-2">
+                            <i data-lucide="terminal" class="w-4 h-4"></i>
+                            Linux (AppImage)
                         </span>
                     </a>
                     <a href="https://github.com/jamditis/audiobash" class="px-6 py-3 border border-white/20 text-chrome font-display font-bold text-sm tracking-wider hover:border-accent hover:text-accent transition-all">
@@ -320,28 +328,28 @@
             </div>
         </section>
 
-        <!-- WHAT'S NEW IN v3.2.0 -->
+        <!-- WHAT'S NEW IN v3.3.0 -->
         <section class="py-16 px-6 bg-accent/5 border-y border-accent/20">
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-8">
-                    <h3 class="font-display text-2xl text-accent mb-2" data-version="NEW IN v{version}">NEW IN v3.2.0</h3>
-                    <p class="text-gray-500 font-mono">Customizable pane colors with activity-based fade</p>
+                    <h3 class="font-display text-2xl text-accent mb-2" data-version="NEW IN v{version}">NEW IN v3.3.0</h3>
+                    <p class="text-gray-500 font-mono">Linux builds, hardened transcription, and Wayland shortcuts</p>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ccff00;">///</div>
-                        <h4 class="font-display text-chrome mb-1">Pane color strips</h4>
-                        <p class="text-gray-500 text-sm">Each pane gets a colored 3px strip that fades through brightness steps as the terminal goes idle.</p>
+                        <h4 class="font-display text-chrome mb-1">Linux downloads</h4>
+                        <p class="text-gray-500 text-sm">AppImage and .deb builds now ship alongside Windows and macOS. One voice terminal, every desktop.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #3399ff;">///</div>
-                        <h4 class="font-display text-chrome mb-1">8-color palette</h4>
-                        <p class="text-gray-500 text-sm">Pick from Emerald, Cobalt, Crimson, Violet, Cyan, Amber, Rose, or Acid. Colors persist across restarts.</p>
+                        <h4 class="font-display text-chrome mb-1">Hardened transcription</h4>
+                        <p class="text-gray-500 text-sm">Cloud transcription now runs in the main process. API keys and provider SDKs never touch the browser layer.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ff3333;">///</div>
-                        <h4 class="font-display text-chrome mb-1">Smarter panes</h4>
-                        <p class="text-gray-500 text-sm">Exit closes panes automatically. Focus tracking fixed for all grid positions. Error exits always show red.</p>
+                        <h4 class="font-display text-chrome mb-1">Wayland shortcuts</h4>
+                        <p class="text-gray-500 text-sm">Global hotkeys register under Wayland, not just X11, so the Alt bindings work on modern Linux desktops.</p>
                     </div>
                 </div>
             </div>
@@ -457,15 +465,15 @@
 
         <!-- DOWNLOAD SECTION -->
         <section id="download" class="py-32 px-6">
-            <div class="max-w-4xl mx-auto text-center">
+            <div class="max-w-5xl mx-auto text-center">
 
                 <div class="bg-panel border border-accent/30 p-12 relative overflow-hidden">
                     <div class="absolute top-0 right-0 w-64 h-64 bg-accent/5 blur-3xl"></div>
 
                     <h3 class="font-display text-4xl text-chrome mb-4 relative">INITIALIZE_NOW</h3>
-                    <p class="text-gray-400 font-mono mb-8 relative">Free and open source. Windows + macOS ready.</p>
+                    <p class="text-gray-400 font-mono mb-8 relative">Free and open source. Windows, macOS, and Linux ready.</p>
 
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 relative mb-8">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 relative mb-8">
                         <!-- Windows -->
                         <div class="bg-void border border-white/10 p-6 text-left">
                             <div class="flex items-center gap-3 mb-4">
@@ -495,6 +503,25 @@
                                 </a>
                                 <a href="#" data-download="mac-intel" class="flex-1 px-4 py-3 border border-apple text-apple font-display font-bold text-center text-sm tracking-wider hover:bg-apple/10 transition-all">
                                     INTEL
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Linux -->
+                        <div class="bg-void border border-white/10 p-6 text-left">
+                            <div class="flex items-center gap-3 mb-4">
+                                <i data-lucide="terminal" class="w-8 h-8 text-linux"></i>
+                                <div>
+                                    <h4 class="font-display text-lg text-chrome">LINUX</h4>
+                                    <p class="text-gray-500 text-xs">Linux x64</p>
+                                </div>
+                            </div>
+                            <div class="flex gap-2">
+                                <a href="#" data-download="linux-appimage" class="flex-1 px-4 py-3 bg-linux text-black font-display font-bold text-center text-sm tracking-wider hover:bg-linux/80 transition-all clip-notch">
+                                    APPIMAGE
+                                </a>
+                                <a href="#" data-download="linux-deb" class="flex-1 px-4 py-3 border border-linux text-linux font-display font-bold text-center text-sm tracking-wider hover:bg-linux/10 transition-all">
+                                    .DEB
                                 </a>
                             </div>
                         </div>
@@ -555,7 +582,7 @@
         <footer class="border-t border-white/10 py-8 px-6">
             <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
                 <div class="text-[10px] text-gray-600 font-mono">
-                    <span data-version="AUDIOBASH v{version} // BUILD 2026.03.10 // MIT LICENSE">AUDIOBASH v3.2.0 // BUILD 2026.03.11 // MIT LICENSE</span>
+                    <span data-version="AUDIOBASH v{version} // BUILD 2026.06.08 // MIT LICENSE">AUDIOBASH v3.3.0 // BUILD 2026.06.08 // MIT LICENSE</span>
                 </div>
                 <div class="flex items-center gap-4 text-gray-500">
                     <a href="about.html" class="hover:text-accent transition-colors text-xs font-mono">

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -3,7 +3,7 @@
  * Single source of truth for version numbers across all docs pages
  */
 
-const AUDIOBASH_VERSION = '3.2.0';
+const AUDIOBASH_VERSION = '3.3.0';
 
 // Auto-populate version strings on page load
 document.addEventListener('DOMContentLoaded', () => {
@@ -25,7 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const urls = {
             'windows': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash.Setup.${AUDIOBASH_VERSION}.exe`,
             'mac-arm64': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash-${AUDIOBASH_VERSION}-arm64.dmg`,
-            'mac-intel': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash-${AUDIOBASH_VERSION}.dmg`
+            'mac-intel': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash-${AUDIOBASH_VERSION}.dmg`,
+            'linux-appimage': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash-${AUDIOBASH_VERSION}.AppImage`,
+            'linux-deb': `${baseUrl}/v${AUDIOBASH_VERSION}/AudioBash-${AUDIOBASH_VERSION}.deb`
         };
 
         if (urls[type]) {

--- a/docs/latest.html
+++ b/docs/latest.html
@@ -213,7 +213,7 @@
 
                         <p class="text-gray-400 mb-6 leading-relaxed">
                             AudioBash now ships AppImage and .deb downloads, so the voice terminal runs on Linux
-                            alongside Windows and macOS. Cloud transcription requests moved into the main process
+                            alongside Windows and macOS. Batch cloud transcription requests moved into the main process
                             instead of the renderer. Global shortcuts register under Wayland, not just X11 — the Alt
                             bindings work on modern Linux desktops.
                         </p>
@@ -231,7 +231,7 @@
                                     <i data-lucide="shield" class="w-5 h-5 text-volt"></i>
                                     <span class="text-chrome font-display">Hardened transcription</span>
                                 </div>
-                                <div class="text-xs text-gray-500">Requests run in the main process</div>
+                                <div class="text-xs text-gray-500">Batch requests run in the main process</div>
                             </div>
                             <div class="bg-void border border-white/10 p-4">
                                 <div class="flex items-center gap-3 mb-2">
@@ -245,7 +245,7 @@
                         <div class="flex flex-wrap gap-3">
                             <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Linux</span>
                             <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">AppImage + .deb</span>
-                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Main-process transcription</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Main-process batch transcription</span>
                             <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Wayland</span>
                         </div>
                     </div>

--- a/docs/latest.html
+++ b/docs/latest.html
@@ -196,6 +196,62 @@
         <!-- UPDATES TIMELINE -->
         <div class="space-y-12">
 
+            <!-- v3.3.0 - Linux builds, hardened transcription, Wayland shortcuts -->
+            <article class="update-card bg-panel border border-white/10 p-8" style="--card-accent: #ccff00;">
+                <div class="flex items-start gap-6">
+                    <div class="feature-icon bg-volt/10 border border-volt/30 shrink-0 hidden sm:flex">
+                        <i data-lucide="monitor-down" class="w-6 h-6 text-volt"></i>
+                    </div>
+                    <div class="flex-1">
+                        <div class="flex flex-wrap items-center gap-3 mb-3">
+                            <span class="px-3 py-1 bg-volt text-black font-display font-bold text-xs">v3.3.0</span>
+                            <span class="text-gray-500 text-sm">June 2026</span>
+                            <span class="px-2 py-0.5 bg-volt/20 text-volt text-xs font-mono">LATEST</span>
+                        </div>
+
+                        <h2 class="font-display text-2xl text-chrome mb-3">Linux lands. Transcription hardens.</h2>
+
+                        <p class="text-gray-400 mb-6 leading-relaxed">
+                            AudioBash now ships AppImage and .deb downloads, so the voice terminal runs on Linux
+                            alongside Windows and macOS. Cloud transcription requests moved into the main process
+                            instead of the renderer. Global shortcuts register under Wayland, not just X11 — the Alt
+                            bindings work on modern Linux desktops.
+                        </p>
+
+                        <div class="grid sm:grid-cols-3 gap-4 mb-6">
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="terminal" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Linux builds</span>
+                                </div>
+                                <div class="text-xs text-gray-500">AppImage and .deb for x64 desktops</div>
+                            </div>
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="shield" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Hardened transcription</span>
+                                </div>
+                                <div class="text-xs text-gray-500">Requests run in the main process</div>
+                            </div>
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="keyboard" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Wayland shortcuts</span>
+                                </div>
+                                <div class="text-xs text-gray-500">Global hotkeys under Wayland</div>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-3">
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Linux</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">AppImage + .deb</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Main-process transcription</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Wayland</span>
+                        </div>
+                    </div>
+                </div>
+            </article>
+
             <!-- v3.0.x - Pane System Overhaul -->
             <article class="update-card bg-panel border border-white/10 p-8" style="--card-accent: #ccff00;">
                 <div class="flex items-start gap-6">
@@ -206,7 +262,6 @@
                         <div class="flex flex-wrap items-center gap-3 mb-3">
                             <span class="px-3 py-1 bg-volt text-black font-display font-bold text-xs">v3.0</span>
                             <span class="text-gray-500 text-sm">March 2026</span>
-                            <span class="px-2 py-0.5 bg-volt/20 text-volt text-xs font-mono">LATEST</span>
                         </div>
 
                         <h2 class="font-display text-2xl text-chrome mb-3">Split panes that actually work.</h2>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -226,7 +226,7 @@
             <div class="mb-12">
                 <div class="inline-flex items-center gap-2 px-3 py-1 bg-accent/10 border border-accent/30 text-accent text-xs font-mono mb-4">
                     <span class="w-2 h-2 bg-accent rounded-full"></span>
-                    <span data-version="v{version}">v3.2.0</span>
+                    <span data-version="v{version}">v3.3.0</span>
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">USER_MANUAL</h1>
                 <p class="text-gray-400 text-lg">Complete guide to installing and using AudioBash on Windows, macOS, and Linux.</p>
@@ -411,17 +411,23 @@
                         <div class="bg-panel border border-white/10 p-6 mb-6">
                             <h4 class="font-display text-chrome mb-3">System requirements</h4>
                             <ul class="text-gray-400 space-y-1 text-sm">
-                                <li>A 64-bit Linux distribution (AppImage and .deb supported)</li>
-                                <li>Node.js 20 or newer and npm</li>
-                                <li>Build tools for native modules (build-essential and python3, to compile node-pty)</li>
+                                <li>A 64-bit Linux distribution (the AppImage runs on most; the .deb is for Debian/Ubuntu)</li>
+                                <li>A glibc-based distro (most mainstream distributions)</li>
                                 <li>4GB RAM minimum (8GB recommended)</li>
                                 <li>Microphone for voice input</li>
                             </ul>
                         </div>
 
-                        <p class="text-gray-400 text-sm mb-4">Prebuilt Linux binaries aren't posted on the releases page yet, so build from source. The repo ships an electron-builder Linux target that produces an AppImage and a .deb.</p>
+                        <h4 class="font-display text-chrome mb-3">Download</h4>
+                        <p class="text-gray-400 text-sm mb-4">Grab a prebuilt build from the releases page: the portable AppImage or a Debian/Ubuntu .deb.</p>
+                        <div class="flex flex-col sm:flex-row gap-3 mb-4">
+                            <a href="#" data-download="linux-appimage" class="px-6 py-3 bg-chrome text-black font-display font-bold text-center text-sm tracking-wider hover:bg-chrome/80 transition-all">DOWNLOAD .APPIMAGE</a>
+                            <a href="#" data-download="linux-deb" class="px-6 py-3 border border-chrome text-chrome font-display font-bold text-center text-sm tracking-wider hover:bg-chrome/10 transition-all">DOWNLOAD .DEB</a>
+                        </div>
+                        <p class="text-gray-400 text-sm mb-8">Make the AppImage executable with <code>chmod +x AudioBash-*.AppImage</code> and run it, or install the .deb with <code>sudo dpkg -i AudioBash-*.deb</code>. Grant microphone access when prompted.</p>
 
-                        <h4 class="font-display text-chrome mb-3">Build steps</h4>
+                        <h4 class="font-display text-chrome mb-3">Or build from source</h4>
+                        <p class="text-gray-400 text-sm mb-4">Prefer to build it yourself? You'll need Node.js 20 or newer and the native build tools (build-essential and python3) to compile node-pty.</p>
                         <ol class="space-y-4 text-gray-400">
                             <li class="flex gap-3">
                                 <span class="w-6 h-6 bg-chrome text-black font-display font-bold text-sm flex items-center justify-center shrink-0">1</span>
@@ -918,7 +924,7 @@ cd audiobash</code></pre>
             <!-- FOOTER -->
             <div class="mt-16 pt-8 border-t border-white/10">
                 <div class="flex flex-col md:flex-row items-center justify-between gap-4 text-gray-500 text-sm">
-                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v3.2.0 - Voice-controlled terminal for Claude Code</div>
+                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v3.3.0 - Voice-controlled terminal for Claude Code</div>
                     <div class="flex items-center gap-4">
                         <a href="about.html" class="hover:text-accent transition-colors">About</a>
                         <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">GitHub</a>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -168,7 +168,7 @@
 
                 <h2 class="font-display text-2xl text-chrome mb-4">Linux builds, hardened transcription, and Wayland shortcuts</h2>
 
-                <p class="text-gray-400 mb-6">AudioBash now ships AppImage and .deb downloads for Linux. Cloud transcription requests now run in the main process instead of the renderer. Global shortcuts register under Wayland, not just X11.</p>
+                <p class="text-gray-400 mb-6">AudioBash now ships AppImage and .deb downloads for Linux. Batch cloud transcription requests now run in the main process instead of the renderer. Global shortcuts register under Wayland, not just X11.</p>
 
                 <!-- Downloads -->
                 <div class="bg-void border border-white/10 p-4 mb-6">
@@ -202,7 +202,7 @@
                         <h4 class="font-display text-signal text-sm mb-2">Platforms</h4>
                         <ul class="text-gray-400 text-sm space-y-1">
                             <li>- <strong>Linux builds</strong> - AppImage and .deb downloads for x64 Linux desktops</li>
-                            <li>- <strong>Hardened transcription</strong> - Cloud transcription requests now run in the main process instead of the renderer</li>
+                            <li>- <strong>Hardened transcription</strong> - Batch cloud transcription requests now run in the main process instead of the renderer</li>
                         </ul>
                     </div>
                     <div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -202,7 +202,7 @@
                         <h4 class="font-display text-signal text-sm mb-2">Platforms</h4>
                         <ul class="text-gray-400 text-sm space-y-1">
                             <li>- <strong>Linux builds</strong> - AppImage and .deb downloads for x64 Linux desktops</li>
-                            <li>- <strong>Hardened transcription</strong> - The Gemini, OpenAI, Anthropic, and ElevenLabs Scribe transcription requests now run in the main process instead of the renderer</li>
+                            <li>- <strong>Hardened transcription</strong> - Cloud transcription requests now run in the main process instead of the renderer</li>
                         </ul>
                     </div>
                     <div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -158,17 +158,17 @@
         <!-- RELEASES -->
         <div class="space-y-8">
 
-            <!-- v3.2.0 -->
+            <!-- v3.3.0 -->
             <article class="release-card latest bg-panel border border-accent/30 p-6">
                 <div class="flex flex-wrap items-center gap-3 mb-4">
-                    <span class="px-3 py-1 bg-accent text-black font-display font-bold text-sm" data-version="v{version}">v3.2.0</span>
+                    <span class="px-3 py-1 bg-accent text-black font-display font-bold text-sm" data-version="v{version}">v3.3.0</span>
                     <span class="px-3 py-1 bg-accent/20 text-accent text-xs font-mono">LATEST</span>
-                    <span class="text-gray-500 text-sm">March 11, 2026</span>
+                    <span class="text-gray-500 text-sm">June 8, 2026</span>
                 </div>
 
-                <h2 class="font-display text-2xl text-chrome mb-4">Customizable pane colors with activity fade</h2>
+                <h2 class="font-display text-2xl text-chrome mb-4">Linux builds, hardened transcription, and Wayland shortcuts</h2>
 
-                <p class="text-gray-400 mb-6">Each pane gets a user-chosen color from an 8-color palette. Colors fade through brightness steps as terminals go idle, and turn red on error exits. Exit now closes panes automatically, and focus tracking works for all grid positions.</p>
+                <p class="text-gray-400 mb-6">AudioBash now ships AppImage and .deb downloads for Linux. Cloud transcription requests now run in the main process instead of the renderer. Global shortcuts register under Wayland, not just X11.</p>
 
                 <!-- Downloads -->
                 <div class="bg-void border border-white/10 p-4 mb-6">
@@ -183,6 +183,61 @@
                             macOS (Apple Silicon)
                         </a>
                         <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                            <i data-lucide="laptop" class="w-4 h-4"></i>
+                            macOS (Intel)
+                        </a>
+                        <a href="#" data-download="linux-appimage" class="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/20 text-chrome text-sm hover:bg-white/10 transition-colors">
+                            <i data-lucide="terminal" class="w-4 h-4"></i>
+                            Linux (AppImage)
+                        </a>
+                        <a href="#" data-download="linux-deb" class="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/20 text-chrome text-sm hover:bg-white/10 transition-colors">
+                            <i data-lucide="package" class="w-4 h-4"></i>
+                            Linux (.deb)
+                        </a>
+                    </div>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-6">
+                    <div>
+                        <h4 class="font-display text-signal text-sm mb-2">Platforms</h4>
+                        <ul class="text-gray-400 text-sm space-y-1">
+                            <li>- <strong>Linux builds</strong> - AppImage and .deb downloads for x64 Linux desktops</li>
+                            <li>- <strong>Hardened transcription</strong> - The Gemini, OpenAI, Anthropic, and ElevenLabs Scribe transcription requests now run in the main process instead of the renderer</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h4 class="font-display text-accent text-sm mb-2">Shortcuts</h4>
+                        <ul class="text-gray-400 text-sm space-y-1">
+                            <li>- <strong>Wayland shortcuts</strong> - Global hotkeys register under Wayland, not just X11, so the Alt bindings work on modern Linux desktops</li>
+                        </ul>
+                    </div>
+                </div>
+            </article>
+
+            <!-- v3.2.0 -->
+            <article class="release-card bg-panel border border-white/10 p-6">
+                <div class="flex flex-wrap items-center gap-3 mb-4">
+                    <span class="px-3 py-1 bg-white/10 text-chrome font-display font-bold text-sm">v3.2.0</span>
+                    <span class="text-gray-500 text-sm">March 11, 2026</span>
+                </div>
+
+                <h2 class="font-display text-2xl text-chrome mb-4">Customizable pane colors with activity fade</h2>
+
+                <p class="text-gray-400 mb-6">Each pane gets a user-chosen color from an 8-color palette. Colors fade through brightness steps as terminals go idle, and turn red on error exits. Exit now closes panes automatically, and focus tracking works for all grid positions.</p>
+
+                <!-- Downloads -->
+                <div class="bg-void border border-white/10 p-4 mb-6">
+                    <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
+                    <div class="grid sm:grid-cols-3 gap-3">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.2.0/AudioBash.Setup.3.2.0.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                            <i data-lucide="monitor" class="w-4 h-4"></i>
+                            Windows
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.2.0/AudioBash-3.2.0-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                            <i data-lucide="cpu" class="w-4 h-4"></i>
+                            macOS (Apple Silicon)
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.2.0/AudioBash-3.2.0.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -261,11 +316,11 @@
                             <i data-lucide="monitor" class="w-4 h-4"></i>
                             Windows
                         </a>
-                        <a href="#" data-download="mac-arm64" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.3/AudioBash-3.0.3-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="cpu" class="w-4 h-4"></i>
                             macOS (Apple Silicon)
                         </a>
-                        <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.3/AudioBash-3.0.3.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -308,15 +363,15 @@
                 <div class="bg-void border border-white/10 p-4 mb-6">
                     <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
                     <div class="grid sm:grid-cols-3 gap-3">
-                        <a href="#" data-download="windows" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.1/AudioBash.Setup.3.0.1.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
                             <i data-lucide="monitor" class="w-4 h-4"></i>
                             Windows
                         </a>
-                        <a href="#" data-download="mac-arm64" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.1/AudioBash-3.0.1-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="cpu" class="w-4 h-4"></i>
                             macOS (Apple Silicon)
                         </a>
-                        <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.1/AudioBash-3.0.1.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -357,15 +412,15 @@
                 <div class="bg-void border border-white/10 p-4 mb-6">
                     <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
                     <div class="grid sm:grid-cols-3 gap-3">
-                        <a href="#" data-download="windows" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.0.0/AudioBash.Setup.3.0.0.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
                             <i data-lucide="monitor" class="w-4 h-4"></i>
                             Windows
                         </a>
-                        <a href="#" data-download="mac-arm64" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/tag/v3.0.0" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="cpu" class="w-4 h-4"></i>
                             macOS (Apple Silicon)
                         </a>
-                        <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/tag/v3.0.0" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -424,15 +479,15 @@
                 <div class="bg-void border border-white/10 p-4 mb-6">
                     <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
                     <div class="grid sm:grid-cols-3 gap-3">
-                        <a href="#" data-download="windows" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.4.1/AudioBash.Setup.2.4.1.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
                             <i data-lucide="monitor" class="w-4 h-4"></i>
                             Windows
                         </a>
-                        <a href="#" data-download="mac-arm64" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.4.1/AudioBash-2.4.1-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="cpu" class="w-4 h-4"></i>
                             macOS (Apple Silicon)
                         </a>
-                        <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.4.1/AudioBash-2.4.1.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -504,15 +559,15 @@
                 <div class="bg-void border border-white/10 p-4 mb-6">
                     <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
                     <div class="grid sm:grid-cols-3 gap-3">
-                        <a href="#" data-download="windows" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.3.6/AudioBash.Setup.2.3.6.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
                             <i data-lucide="monitor" class="w-4 h-4"></i>
                             Windows
                         </a>
-                        <a href="#" data-download="mac-arm64" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.3.6/AudioBash-2.3.6-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="cpu" class="w-4 h-4"></i>
                             macOS (Apple Silicon)
                         </a>
-                        <a href="#" data-download="mac-intel" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v2.3.6/AudioBash-2.3.6.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
                             <i data-lucide="laptop" class="w-4 h-4"></i>
                             macOS (Intel)
                         </a>
@@ -984,10 +1039,6 @@
                         <li class="flex items-center gap-2">
                             <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
                             Project-based pane layouts
-                        </li>
-                        <li class="flex items-center gap-2">
-                            <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
-                            Linux support (AppImage, .deb)
                         </li>
                     </ul>
                 </div>

--- a/electron/featureFlags.cjs
+++ b/electron/featureFlags.cjs
@@ -8,8 +8,22 @@
 // for security, so global shortcuts silently no-op unless the app opts into Chromium's
 // GlobalShortcutsPortal feature (routes through the xdg-desktop-portal GlobalShortcuts API).
 // See electron/electron#45171.
+//
+// Chromium keeps only the LAST value of a repeated --enable-features switch, so we merge our feature
+// into any value already on the command line (e.g. a Linux desktop entry enabling Ozone/Wayland
+// flags) instead of overwriting it.
 function enableWaylandShortcuts(app) {
-  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal');
+  const existing = app.commandLine.getSwitchValue('enable-features');
+  const features = existing
+    ? existing
+        .split(',')
+        .map((feature) => feature.trim())
+        .filter(Boolean)
+    : [];
+  if (!features.includes('GlobalShortcutsPortal')) {
+    features.push('GlobalShortcutsPortal');
+  }
+  app.commandLine.appendSwitch('enable-features', features.join(','));
 }
 
 module.exports = { enableWaylandShortcuts };

--- a/electron/featureFlags.cjs
+++ b/electron/featureFlags.cjs
@@ -1,0 +1,15 @@
+// Chromium/Electron command-line feature flags, set before the app `ready` event.
+//
+// Extracted from main.cjs so the flag wiring can be unit-tested in isolation. These switches must be
+// appended at module load (before `ready`); setting them inside app.whenReady() is too late because
+// Chromium has already initialized its feature set.
+
+// Electron's globalShortcut API talks to X11's XGrabKey directly. Under Wayland that grab is denied
+// for security, so global shortcuts silently no-op unless the app opts into Chromium's
+// GlobalShortcutsPortal feature (routes through the xdg-desktop-portal GlobalShortcuts API).
+// See electron/electron#45171.
+function enableWaylandShortcuts(app) {
+  app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal');
+}
+
+module.exports = { enableWaylandShortcuts };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -19,6 +19,11 @@ const crypto = require('crypto');
 // Centralized logger - must initialize after app ready
 const { logger, appLog, ipcLog, ptyLog, storeLog } = require('./logger.cjs');
 
+// Enable Chromium feature flags before the app is ready (too late inside whenReady). This lets
+// global shortcuts register under Wayland, not just X11.
+const { enableWaylandShortcuts } = require('./featureFlags.cjs');
+enableWaylandShortcuts(app);
+
 // Global error handlers to prevent silent crashes (fixes #29)
 process.on('uncaughtException', (err) => {
   console.error('[AudioBash] Uncaught exception:', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audiobash",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audiobash",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiobash",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Voice-controlled terminal for Claude Code",
   "main": "electron/main.cjs",
   "author": "Joe Amditis",
@@ -162,6 +162,7 @@
         "AppImage",
         "deb"
       ],
+      "artifactName": "${productName}-${version}.${ext}",
       "icon": "audiobash-logo.png",
       "category": "Development"
     }

--- a/tests/unit/docsReleases.test.ts
+++ b/tests/unit/docsReleases.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Regression guard for the v3.2.0-entry-relabel bug: docs/js/version.js rewrites every element
+// carrying data-version="v{version}" to the global AUDIOBASH_VERSION on page load. The releases
+// page freezes one entry per shipped version, so only the newest (latest) entry may use that
+// template. When a release bumps the version without freezing the prior latest entry, the old
+// entry's badge gets silently relabeled to the new version while keeping its old date and notes
+// (e.g. the March 11 pane-colors v3.2.0 entry rendering as "v3.3.0"). Frozen historical entries
+// must hardcode their version badge so a version bump cannot rewrite them.
+
+const releasesHtml = readFileSync(join(__dirname, '..', '..', 'docs', 'releases.html'), 'utf8');
+const doc = new DOMParser().parseFromString(releasesHtml, 'text/html');
+
+const versionJs = readFileSync(join(__dirname, '..', '..', 'docs', 'js', 'version.js'), 'utf8');
+const currentVersion = versionJs.match(/AUDIOBASH_VERSION\s*=\s*'([^']+)'/)?.[1];
+
+function findCardByHeading(fragment: string): Element {
+  const cards = Array.from(doc.querySelectorAll('article.release-card'));
+  const match = cards.find((card) =>
+    (card.querySelector('h2')?.textContent ?? '').toLowerCase().includes(fragment.toLowerCase()),
+  );
+  if (!match) throw new Error(`No release card whose heading contains "${fragment}"`);
+  return match;
+}
+
+function nonLatestCards(): Element[] {
+  return Array.from(doc.querySelectorAll('article.release-card')).filter(
+    (card) => !card.classList.contains('latest'),
+  );
+}
+
+describe('docs/releases.html version freezing', () => {
+  it('marks exactly one release card as the latest', () => {
+    const latest = doc.querySelectorAll('article.release-card.latest');
+    expect(latest).toHaveLength(1);
+  });
+
+  it('freezes the v3.2.0 pane-colors entry with a hardcoded version badge', () => {
+    const card = findCardByHeading('pane colors');
+    const templatedBadge = card.querySelector('[data-version="v{version}"]');
+    expect(templatedBadge).toBeNull();
+    // The frozen badge must literally read v3.2.0, not a template that version.js can overwrite.
+    const badge = card.querySelector('span[class*="bg-accent"], span[class*="bg-white"]');
+    expect(badge?.textContent?.trim()).toBe('v3.2.0');
+  });
+
+  it('no longer marks the v3.2.0 pane-colors entry as latest', () => {
+    const card = findCardByHeading('pane colors');
+    expect(card.classList.contains('latest')).toBe(false);
+  });
+
+  it('points the latest badge at a newer entry than the v3.2.0 pane-colors release', () => {
+    const latest = doc.querySelector('article.release-card.latest');
+    const paneColors = findCardByHeading('pane colors');
+    expect(latest).not.toBeNull();
+    expect(latest).not.toBe(paneColors);
+    // The latest card keeps the template so its badge tracks the shipped version.
+    expect(latest?.querySelector('[data-version="v{version}"]')).not.toBeNull();
+  });
+
+  it('freezes the v3.2.0 entry download links to v3.2.0 assets, not the latest version', () => {
+    const card = findCardByHeading('pane colors');
+    // data-download links are repointed at the latest version by version.js, so a frozen entry
+    // must use hardcoded v3.2.0 URLs instead.
+    expect(card.querySelector('[data-download]')).toBeNull();
+    const downloads = Array.from(card.querySelectorAll('a[href*="/releases/download/"]'));
+    expect(downloads.length).toBeGreaterThan(0);
+    for (const link of downloads) {
+      expect(link.getAttribute('href')).toContain('/download/v3.2.0/');
+    }
+  });
+
+  // version.js also repoints every [data-download] link at the latest version's assets, so the same
+  // freeze must hold for the download buttons on every historical card, not just v3.2.0 — otherwise
+  // old entries silently link to the newest installers.
+  it('uses no templated download links on any non-latest release card', () => {
+    for (const card of nonLatestCards()) {
+      const version = card.querySelector('span')?.textContent?.trim() ?? '(unknown)';
+      expect(
+        card.querySelectorAll('[data-download]').length,
+        `frozen card ${version} still has a templated [data-download] link`,
+      ).toBe(0);
+    }
+  });
+
+  it('never links a frozen historical entry at the current version download assets', () => {
+    expect(currentVersion, 'could not parse AUDIOBASH_VERSION from version.js').toBeTruthy();
+    const currentPath = `/download/v${currentVersion}/`;
+    for (const card of nonLatestCards()) {
+      const version = card.querySelector('span')?.textContent?.trim() ?? '(unknown)';
+      const stray = Array.from(card.querySelectorAll('a[href]')).filter((a) =>
+        (a.getAttribute('href') ?? '').includes(currentPath),
+      );
+      expect(stray.length, `frozen card ${version} links at the current version's assets`).toBe(0);
+    }
+  });
+});

--- a/tests/unit/docsReleases.test.ts
+++ b/tests/unit/docsReleases.test.ts
@@ -97,3 +97,33 @@ describe('docs/releases.html version freezing', () => {
     }
   });
 });
+
+// Regression guard for the recurring "hardened transcription" overstatement. The v3.3.0 security
+// work moved the batch (request/response) cloud transcription path into the main process, but the
+// real-time ElevenLabs path still builds a browser WebSocket with xi-api-key in the renderer
+// (src/services/elevenLabsRealtimeService.ts). So an unqualified "cloud transcription now runs in
+// the main process" claim is false for that path. Every v3.3.0 doc page must scope the claim to
+// batch. This was flagged three separate times before it stuck.
+describe('docs do not overstate the transcription hardening', () => {
+  // Matches the sentence-level claim that transcription requests now run/moved in(to) the main
+  // process. Each occurrence must be qualified with "batch" in its immediate lead-in.
+  const claimRe = /transcription requests (?:now run|moved) (?:in|into) the main process/g;
+
+  for (const name of ['releases.html', 'index.html', 'latest.html']) {
+    it(`scopes the main-process transcription claim to batch in ${name}`, () => {
+      const html = readFileSync(join(__dirname, '..', '..', 'docs', name), 'utf8').toLowerCase();
+      const matches = [...html.matchAll(claimRe)];
+      expect(
+        matches.length,
+        `expected at least one main-process transcription claim in ${name}`,
+      ).toBeGreaterThan(0);
+      for (const m of matches) {
+        const leadIn = html.slice(Math.max(0, m.index - 30), m.index);
+        expect(
+          leadIn,
+          `unqualified transcription claim in ${name}: "...${html.slice(Math.max(0, m.index - 30), m.index + 50)}..."`,
+        ).toContain('batch');
+      }
+    });
+  }
+});

--- a/tests/unit/featureFlags.test.ts
+++ b/tests/unit/featureFlags.test.ts
@@ -26,10 +26,7 @@ describe('enableWaylandShortcuts', () => {
 describe('main process wiring', () => {
   // main.cjs is too coupled to load in jsdom, so guard the wiring with a source check (same approach
   // as startup-crash.test.ts). The flag must be applied at module load, before app.whenReady() runs.
-  const mainProcessCode = readFileSync(
-    join(__dirname, '..', '..', 'electron', 'main.cjs'),
-    'utf8',
-  );
+  const mainProcessCode = readFileSync(join(__dirname, '..', '..', 'electron', 'main.cjs'), 'utf8');
 
   it('calls enableWaylandShortcuts before app.whenReady so the switch is set before ready', () => {
     expect(mainProcessCode).toContain('enableWaylandShortcuts(app)');

--- a/tests/unit/featureFlags.test.ts
+++ b/tests/unit/featureFlags.test.ts
@@ -15,7 +15,34 @@ describe('enableWaylandShortcuts', () => {
   // real app.commandLine the main process passes in.
   it('appends the GlobalShortcutsPortal feature so global shortcuts work under Wayland', () => {
     const appendSwitch = vi.fn();
-    const app = { commandLine: { appendSwitch } };
+    const getSwitchValue = vi.fn().mockReturnValue('');
+    const app = { commandLine: { appendSwitch, getSwitchValue } };
+
+    enableWaylandShortcuts(app);
+
+    expect(appendSwitch).toHaveBeenCalledWith('enable-features', 'GlobalShortcutsPortal');
+  });
+
+  // Chromium keeps only the last value of a repeated --enable-features switch, so blindly appending
+  // would drop any feature list a desktop entry or QA run passed in. We must merge, not overwrite.
+  it('merges GlobalShortcutsPortal into an existing enable-features value instead of overwriting it', () => {
+    const appendSwitch = vi.fn();
+    const getSwitchValue = vi.fn().mockReturnValue('SomeFeature,AnotherFeature');
+    const app = { commandLine: { appendSwitch, getSwitchValue } };
+
+    enableWaylandShortcuts(app);
+
+    expect(getSwitchValue).toHaveBeenCalledWith('enable-features');
+    expect(appendSwitch).toHaveBeenCalledWith(
+      'enable-features',
+      'SomeFeature,AnotherFeature,GlobalShortcutsPortal',
+    );
+  });
+
+  it('does not duplicate GlobalShortcutsPortal if it is already enabled', () => {
+    const appendSwitch = vi.fn();
+    const getSwitchValue = vi.fn().mockReturnValue('GlobalShortcutsPortal');
+    const app = { commandLine: { appendSwitch, getSwitchValue } };
 
     enableWaylandShortcuts(app);
 

--- a/tests/unit/featureFlags.test.ts
+++ b/tests/unit/featureFlags.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Load the CommonJS module exactly as Node/Electron does, so the test exercises the real
+// module.exports the main process consumes (no vite ESM-interop ambiguity).
+const require = createRequire(import.meta.url);
+const { enableWaylandShortcuts } = require('../../electron/featureFlags.cjs');
+
+describe('enableWaylandShortcuts', () => {
+  // Regression guard for the Wayland global-shortcut bug: Electron's globalShortcut API silently
+  // no-ops under Wayland unless the app opts into Chromium's GlobalShortcutsPortal feature. We can't
+  // reproduce an actual Wayland grab in CI, so we assert the documented switch is applied to the
+  // real app.commandLine the main process passes in.
+  it('appends the GlobalShortcutsPortal feature so global shortcuts work under Wayland', () => {
+    const appendSwitch = vi.fn();
+    const app = { commandLine: { appendSwitch } };
+
+    enableWaylandShortcuts(app);
+
+    expect(appendSwitch).toHaveBeenCalledWith('enable-features', 'GlobalShortcutsPortal');
+  });
+});
+
+describe('main process wiring', () => {
+  // main.cjs is too coupled to load in jsdom, so guard the wiring with a source check (same approach
+  // as startup-crash.test.ts). The flag must be applied at module load, before app.whenReady() runs.
+  const mainProcessCode = readFileSync(
+    join(__dirname, '..', '..', 'electron', 'main.cjs'),
+    'utf8',
+  );
+
+  it('calls enableWaylandShortcuts before app.whenReady so the switch is set before ready', () => {
+    expect(mainProcessCode).toContain('enableWaylandShortcuts(app)');
+
+    const callIndex = mainProcessCode.indexOf('enableWaylandShortcuts(app)');
+    const whenReadyIndex = mainProcessCode.indexOf('app.whenReady()');
+    expect(callIndex).toBeGreaterThan(-1);
+    expect(whenReadyIndex).toBeGreaterThan(-1);
+    expect(callIndex).toBeLessThan(whenReadyIndex);
+  });
+});


### PR DESCRIPTION
## What this is

Cuts v3.3.0. Ships the work that has accumulated on master since v3.2.0 and adds two new things: first-class Linux downloads and a Wayland global-shortcut fix.

## Changes

### Wayland global shortcuts (app code)
Electron's `globalShortcut` uses X11's `XGrabKey`, which Wayland denies, so global shortcuts silently no-op under Wayland. This opts into Chromium's `GlobalShortcutsPortal` feature before the app `ready` event. The switch wiring is extracted into `electron/featureFlags.cjs` and unit-tested (`tests/unit/featureFlags.test.ts` covers both the behavior and that it runs before `app.whenReady`).

### Linux builds
- `build.yml` builds AppImage + deb on tag push and attaches them to the draft release. `build_linux` now defaults on, matching mac/windows, so the dispatch-from-tag release path isn't blocked by a skipped dependency.
- `package.json` pins the Linux `artifactName` so download URLs are deterministic (`AudioBash-3.3.0.AppImage`, `AudioBash-3.3.0.deb`).

### Version + docs
- Bump to 3.3.0 in `package.json` and `docs/js/version.js` (the docs version source), plus the hardcoded fallbacks in `index.html` / `manual.html`.
- Add Linux download links and install steps to the site (`index.html`, `manual.html`) and README.
- Fix the stale shortcut count (16 -> 20) and reconcile the provider list in the README.

## Tests

425 passed, 18 skipped, 0 failures (the macos-stress file skips off macOS). The new Wayland test fails before the flag is added and passes after.

## Release follow-up (after merge)

Tagging `v3.3.0` triggers the four-platform CI build and a draft release. Draft asset names get verified against the docs URLs, the notes get the release-process template, and the arm64 DMG gets a smoke-test on Apple Silicon before publish.
