### PR TITLE
Fix Linux .deb build by setting the package maintainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
       ],
       "artifactName": "${productName}-${version}.${ext}",
       "icon": "audiobash-logo.png",
-      "category": "Development"
+      "category": "Development",
+      "maintainer": "Joe Amditis <amditisj@montclair.edu>"
     }
   }
 }

--- a/tests/build-config.test.ts
+++ b/tests/build-config.test.ts
@@ -120,8 +120,11 @@ describe('Linux build configuration', () => {
   // unless package.json author is an object with an email, or build.linux.maintainer is set.
   // author was a bare "Joe Amditis" string, so the deb step failed in CI and blocked the release job.
   it('provides a maintainer email for the deb target', () => {
-    const targets = buildConfig.linux.target ?? [];
-    if (!targets.includes('deb')) return;
+    const rawTargets = buildConfig.linux.target ?? [];
+    const targetNames = (Array.isArray(rawTargets) ? rawTargets : [rawTargets]).map((t: any) =>
+      typeof t === 'string' ? t : t?.target,
+    );
+    if (!targetNames.includes('deb')) return;
     const author = packageJson.author;
     const authorEmail = author && typeof author === 'object' ? author.email : undefined;
     const source = buildConfig.linux.maintainer || authorEmail || '';

--- a/tests/build-config.test.ts
+++ b/tests/build-config.test.ts
@@ -114,6 +114,21 @@ describe('Linux build configuration', () => {
     expect(buildConfig.linux.target).toContain('AppImage');
     expect(buildConfig.linux.target).toContain('deb');
   });
+
+  // Regression guard for the v3.3.0 tag build: electron-builder's .deb (fpm) target fails the whole
+  // build with "Please specify author 'email' ... required to set Linux .deb package maintainer"
+  // unless package.json author is an object with an email, or build.linux.maintainer is set.
+  // author was a bare "Joe Amditis" string, so the deb step failed in CI and blocked the release job.
+  it('provides a maintainer email for the deb target', () => {
+    const targets = buildConfig.linux.target ?? [];
+    if (!targets.includes('deb')) return;
+    const author = packageJson.author;
+    const authorEmail = author && typeof author === 'object' ? author.email : undefined;
+    const source = buildConfig.linux.maintainer || authorEmail || '';
+    expect(source, 'deb target needs author.email or build.linux.maintainer').toMatch(
+      /[^\s@]+@[^\s@]+\.[^\s@]+/,
+    );
+  });
 });
 
 describe('npm scripts', () => {


### PR DESCRIPTION
## Problem

The `v3.3.0` tag build failed in the `build-linux` job:

```
⨯ Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer.
```

electron-builder's `.deb` (fpm) target needs a maintainer, derived from `author.email` or `build.linux.maintainer`. `package.json` had `author` as the bare string `"Joe Amditis"` (no email) and no `build.linux.maintainer`, so the `.deb` step aborted.

Because the `release` job is `needs: [build-mac, build-windows, build-linux]`, the Linux failure blocked the entire draft release — even the successful Windows build never got attached.

This is a config issue, not an environment one: ubuntu-latest builds Linux fine; it just needs the maintainer field. Rebuilding on another machine would fail identically.

## Fix

- Set `build.linux.maintainer` to `Joe Amditis <amditisj@montclair.edu>` so the `.deb` target has a maintainer.
- Add a `build-config` regression test that fails whenever the `deb` target lacks a resolvable maintainer email (`author.email` or `build.linux.maintainer`), so a tag build can't be blocked by this again.

## Verification

- `build-config` suite: 26 passed (new guard included)
- `package.json` is valid JSON, prettier clean

After merge, the `v3.3.0` tag will be moved to the fixed commit to retrigger the full multi-platform build.