### PR TITLE
docs: sync releases.html roadmap with shipped state

### DIFF
--- a/docs/releases.html
+++ b/docs/releases.html
@@ -973,11 +973,15 @@
                     </div>
                     <ul class="text-gray-400 text-sm space-y-2">
                         <li class="flex items-center gap-2">
-                            <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
+                            <span class="w-4 h-4 bg-accent flex items-center justify-center flex-shrink-0">
+                                <svg class="w-3 h-3 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            </span>
                             Pane system hardening
                         </li>
                         <li class="flex items-center gap-2">
-                            <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
+                            <span class="w-4 h-4 bg-accent flex items-center justify-center flex-shrink-0">
+                                <svg class="w-3 h-3 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            </span>
                             Voice pipeline reliability
                         </li>
                         <li class="flex items-center gap-2">
@@ -1033,7 +1037,9 @@
                             Auto-update via electron-updater
                         </li>
                         <li class="flex items-center gap-2">
-                            <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
+                            <span class="w-4 h-4 bg-apple flex items-center justify-center flex-shrink-0">
+                                <svg class="w-3 h-3 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            </span>
                             Named terminal sessions
                         </li>
                         <li class="flex items-center gap-2">
@@ -1051,7 +1057,9 @@
                     </div>
                     <ul class="text-gray-500 text-sm space-y-2">
                         <li class="flex items-center gap-2">
-                            <span class="w-4 h-4 border border-white/20 flex-shrink-0"></span>
+                            <span class="w-4 h-4 bg-gray-500 flex items-center justify-center flex-shrink-0">
+                                <svg class="w-3 h-3 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                            </span>
                             Local transcription (whisper.cpp)
                         </li>
                         <li class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

The roadmap at the bottom of [releases.html](https://audiobash.app/releases.html) listed several already-shipped features as unchecked. The app is now at **v3.3.0**, so this checks off the items that have actually shipped.

Per direction, this is a minimal "check off in place" change — the existing v3.1/v3.5/v4.0 milestone cards and labels are kept as-is; only the checkboxes for completed items are filled.

## Items checked off

| Item | Shipped in | Card |
|------|-----------|------|
| Pane system hardening | v3.0.3, v3.2.0 | v3.1 |
| Voice pipeline reliability | v3.3.0 (hardened transcription) | v3.1 |
| Named terminal sessions | v3.0.0 (save/load layouts) | v4.0 |
| Local transcription (whisper.cpp) | shipped, exposed in Settings UI | Future |

Each checked box is filled with a checkmark in its card's tier color (accent / apple / gray) to stay consistent with the void/brutalist aesthetic.

## Still pending (left unchecked)

Customizable keyboard shortcuts, performance optimization, voice command history, continuous listening, wake word, audio input device selection (infra exists but no UI), macOS notarization (signing shipped in v3.1.0 but the line item bundles notarization, which is still pending), auto-update, project-based pane layouts, multi-language transcription, session recording, and custom voice command aliases.

https://claude.ai/code/session_01PMTGd5rkPRt4w2AFL56nEn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMTGd5rkPRt4w2AFL56nEn)_