### PR TITLE
Apply custom vocabulary corrections to local transcription models

### DIFF
--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -757,7 +757,10 @@ export class TranscriptionService {
       }
 
       log.debug('Parakeet transcription successful', { textLength: data.text?.length || 0 });
-      return { text: data.text || '', cost: '$0.00 (Local)' };
+      // Local models have no prompt-injection path for custom vocabulary, so apply the same
+      // post-transcription corrections used by the cloud raw-mode paths (see issue #41).
+      const text = this.applyVocabularyCorrections((data.text || '').trim());
+      return { text, cost: '$0.00 (Local)' };
     } catch (e: unknown) {
       if (e instanceof TranscriptionError) throw e;
 
@@ -829,8 +832,11 @@ export class TranscriptionService {
       }
 
       log.debug('Whisper transcription successful', { textLength: result.text?.length || 0 });
+      // whisper.cpp is invoked with no initial prompt, so custom vocabulary can't bias decoding.
+      // Apply the post-transcription corrections to match the cloud raw-mode paths (see issue #41).
+      const text = this.applyVocabularyCorrections((result.text || '').trim());
       return {
-        text: result.text || '',
+        text,
         cost: '$0.00 (Local)',
       };
     } catch (e: unknown) {

--- a/tests/unit/transcriptionService.test.ts
+++ b/tests/unit/transcriptionService.test.ts
@@ -479,6 +479,68 @@ describe('Vocabulary Corrections', () => {
   });
 });
 
+describe('Local model vocabulary corrections', () => {
+  // Regression test for #41: custom dictionary entries were silently ignored by the local
+  // Parakeet and Whisper paths because applyVocabularyCorrections() was only called in the
+  // cloud raw-mode paths.
+  let service: TranscriptionService;
+
+  beforeEach(() => {
+    service = new TranscriptionService();
+    service.setCustomInstructions({
+      rawModeInstructions: '',
+      agentModeInstructions: '',
+      vocabulary: [{ spoken: 'audio bash', written: 'AudioBash' }],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies vocabulary corrections to local Parakeet transcriptions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ text: 'open audio bash now' }),
+          text: () => Promise.resolve(''),
+        } as Response),
+      ),
+    );
+
+    const result = await service.transcribeAudio(
+      createMockAudioBlob(),
+      'raw',
+      'parakeet-local',
+      1000,
+    );
+
+    expect(result.text).toBe('open AudioBash now');
+  });
+
+  it('applies vocabulary corrections to local Whisper transcriptions', async () => {
+    window.electron.whisperSetModel = vi.fn(() => Promise.resolve());
+    window.electron.saveTempAudio = vi.fn(() =>
+      Promise.resolve({ success: true, path: '/tmp/audio.webm' }),
+    );
+    window.electron.whisperTranscribe = vi.fn(() =>
+      Promise.resolve({ text: 'launch audio bash please' }),
+    );
+
+    const result = await service.transcribeAudio(
+      createMockAudioBlob(),
+      'raw',
+      'whisper-local-small',
+      1000,
+    );
+
+    expect(result.text).toBe('launch AudioBash please');
+  });
+});
+
 describe('Service State', () => {
   it('multiple service instances are independent', () => {
     const service1 = new TranscriptionService();


### PR DESCRIPTION
## Summary

The custom dictionary (vocabulary / custom pronunciations) was silently ignored when using the local transcription models (Parakeet local and Whisper local), so configured `spoken → written` entries never took effect.

`applyVocabularyCorrections()` — the post-transcription regex pass that rewrites spoken forms to written forms — was only called in the cloud raw-mode paths (`transcribeWithOpenAI`, `transcribeWithAnthropic`). The local paths returned the model text directly, and local models have no prompt-injection fallback either (whisper.cpp is invoked with no initial prompt), so the dictionary had no delivery mechanism at all.

## Changes

- `transcribeLocal` (Parakeet) now applies `applyVocabularyCorrections()` to the returned text before returning.
- `transcribeLocalWhisper` now applies `applyVocabularyCorrections()` to the returned text before returning.
- Both trim the text first, matching the cloud raw-mode behavior.

## Tests

Added regression tests in `tests/unit/transcriptionService.test.ts` asserting that a configured vocabulary entry (`audio bash → AudioBash`) is applied to the text returned by both `transcribeLocal` and `transcribeLocalWhisper`.

Full suite: **440 passed**, 18 skipped, 0 failures.

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKwmm255oumakXpMjYk7NW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKwmm255oumakXpMjYk7NW)_