### PR TITLE
v3.3.1 — custom dictionary now applies to local transcription

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -221,7 +221,7 @@
                 <div class="w-10 h-10 bg-accent text-black flex items-center justify-center font-bold font-display text-xl clip-notch">A</div>
                 <div>
                     <h1 class="font-display font-bold text-lg tracking-wider text-chrome">AUDIOBASH</h1>
-                    <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v3.3.0 // VOICE_TERMINAL</p>
+                    <p class="text-[9px] text-gray-500 tracking-[0.2em]" data-version="v{version} // VOICE_TERMINAL">v3.3.1 // VOICE_TERMINAL</p>
                 </div>
             </div>
             <div class="flex items-center gap-4">
@@ -253,7 +253,7 @@
                 <!-- NEW: Version Badge -->
                 <a href="latest.html" class="inline-flex items-center gap-2 px-4 py-2 bg-accent/10 border border-accent/30 text-accent text-sm font-mono mb-6 hover:bg-accent/20 transition-colors">
                     <span class="w-2 h-2 bg-accent rounded-full animate-pulse"></span>
-                    <span data-version="v{version}">v3.3.0</span> — Linux builds, hardened transcription, Wayland shortcuts
+                    <span data-version="v{version}">v3.3.1</span> — custom dictionary now applies to local Whisper and Parakeet
                     <i data-lucide="arrow-right" class="w-4 h-4"></i>
                 </a>
 
@@ -340,28 +340,28 @@
             </div>
         </section>
 
-        <!-- WHAT'S NEW IN v3.3.0 -->
+        <!-- WHAT'S NEW IN v3.3.1 -->
         <section class="py-16 px-6 bg-accent/5 border-y border-accent/20">
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-8">
-                    <h3 class="font-display text-2xl text-accent mb-2" data-version="NEW IN v{version}">NEW IN v3.3.0</h3>
-                    <p class="text-gray-500 font-mono">Linux builds, hardened transcription, and Wayland shortcuts</p>
+                    <h3 class="font-display text-2xl text-accent mb-2" data-version="NEW IN v{version}">NEW IN v3.3.1</h3>
+                    <p class="text-gray-500 font-mono">Your custom dictionary now applies to local transcription, not just cloud</p>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ccff00;">///</div>
-                        <h4 class="font-display text-chrome mb-1">Linux downloads</h4>
-                        <p class="text-gray-500 text-sm">AppImage and .deb builds now ship alongside Windows and macOS. One voice terminal, every desktop.</p>
+                        <h4 class="font-display text-chrome mb-1">Dictionary fix for local models</h4>
+                        <p class="text-gray-500 text-sm">The custom dictionary was silently ignored by local Whisper and Parakeet. Configured spoken-to-written corrections now apply to their output too.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #3399ff;">///</div>
-                        <h4 class="font-display text-chrome mb-1">Hardened transcription</h4>
-                        <p class="text-gray-500 text-sm">Batch cloud transcription requests now run in the main process instead of the renderer.</p>
+                        <h4 class="font-display text-chrome mb-1">Same behavior as cloud</h4>
+                        <p class="text-gray-500 text-sm">Local engines now run the same vocabulary corrections the Gemini, OpenAI, and Anthropic paths already used.</p>
                     </div>
                     <div class="p-4">
                         <div class="text-3xl mb-2 font-mono" style="color: #ff3333;">///</div>
-                        <h4 class="font-display text-chrome mb-1">Wayland shortcuts</h4>
-                        <p class="text-gray-500 text-sm">Global hotkeys register under Wayland, not just X11, so the Alt bindings work on modern Linux desktops.</p>
+                        <h4 class="font-display text-chrome mb-1">Regression-tested</h4>
+                        <p class="text-gray-500 text-sm">New tests assert a configured dictionary entry is applied on both the Parakeet and Whisper paths.</p>
                     </div>
                 </div>
             </div>
@@ -594,7 +594,7 @@
         <footer class="border-t border-white/10 py-8 px-6">
             <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
                 <div class="text-[10px] text-gray-600 font-mono">
-                    <span data-version="AUDIOBASH v{version} // BUILD 2026.06.08 // MIT LICENSE">AUDIOBASH v3.3.0 // BUILD 2026.06.08 // MIT LICENSE</span>
+                    <span data-version="AUDIOBASH v{version} // BUILD 2026.06.21 // MIT LICENSE">AUDIOBASH v3.3.1 // BUILD 2026.06.21 // MIT LICENSE</span>
                 </div>
                 <div class="flex items-center gap-4 text-gray-500">
                     <a href="about.html" class="hover:text-accent transition-colors text-xs font-mono">

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -3,7 +3,7 @@
  * Single source of truth for version numbers across all docs pages
  */
 
-const AUDIOBASH_VERSION = '3.3.0';
+const AUDIOBASH_VERSION = '3.3.1';
 
 // Auto-populate version strings on page load
 document.addEventListener('DOMContentLoaded', () => {

--- a/docs/latest.html
+++ b/docs/latest.html
@@ -196,6 +196,60 @@
         <!-- UPDATES TIMELINE -->
         <div class="space-y-12">
 
+            <!-- v3.3.1 - Custom dictionary on local transcription -->
+            <article class="update-card bg-panel border border-white/10 p-8" style="--card-accent: #ccff00;">
+                <div class="flex items-start gap-6">
+                    <div class="feature-icon bg-volt/10 border border-volt/30 shrink-0 hidden sm:flex">
+                        <i data-lucide="spell-check" class="w-6 h-6 text-volt"></i>
+                    </div>
+                    <div class="flex-1">
+                        <div class="flex flex-wrap items-center gap-3 mb-3">
+                            <span class="px-3 py-1 bg-volt text-black font-display font-bold text-xs">v3.3.1</span>
+                            <span class="text-gray-500 text-sm">June 2026</span>
+                            <span class="px-2 py-0.5 bg-volt/20 text-volt text-xs font-mono">LATEST</span>
+                        </div>
+
+                        <h2 class="font-display text-2xl text-chrome mb-3">Custom dictionary now works on local transcription.</h2>
+
+                        <p class="text-gray-400 mb-6 leading-relaxed">
+                            The custom dictionary was silently ignored by the local Whisper and Parakeet paths — configured
+                            corrections only applied to the cloud providers. Now spoken-to-written entries apply to local model
+                            output too, matching the Gemini, OpenAI, and Anthropic behavior. Regression tests cover both local paths.
+                        </p>
+
+                        <div class="grid sm:grid-cols-3 gap-4 mb-6">
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="book-marked" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Local dictionary</span>
+                                </div>
+                                <div class="text-xs text-gray-500">Corrections apply to Whisper and Parakeet</div>
+                            </div>
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="git-compare" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Matches cloud</span>
+                                </div>
+                                <div class="text-xs text-gray-500">Same behavior as the cloud providers</div>
+                            </div>
+                            <div class="bg-void border border-white/10 p-4">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <i data-lucide="check-check" class="w-5 h-5 text-volt"></i>
+                                    <span class="text-chrome font-display">Regression-tested</span>
+                                </div>
+                                <div class="text-xs text-gray-500">New tests on both local paths</div>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-3">
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Custom dictionary</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Local Whisper</span>
+                            <span class="px-3 py-1.5 bg-volt/10 border border-volt/30 text-volt text-xs">Parakeet</span>
+                        </div>
+                    </div>
+                </div>
+            </article>
+
             <!-- v3.3.0 - Linux builds, hardened transcription, Wayland shortcuts -->
             <article class="update-card bg-panel border border-white/10 p-8" style="--card-accent: #ccff00;">
                 <div class="flex items-start gap-6">
@@ -206,7 +260,6 @@
                         <div class="flex flex-wrap items-center gap-3 mb-3">
                             <span class="px-3 py-1 bg-volt text-black font-display font-bold text-xs">v3.3.0</span>
                             <span class="text-gray-500 text-sm">June 2026</span>
-                            <span class="px-2 py-0.5 bg-volt/20 text-volt text-xs font-mono">LATEST</span>
                         </div>
 
                         <h2 class="font-display text-2xl text-chrome mb-3">Linux lands. Transcription hardens.</h2>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -226,7 +226,7 @@
             <div class="mb-12">
                 <div class="inline-flex items-center gap-2 px-3 py-1 bg-accent/10 border border-accent/30 text-accent text-xs font-mono mb-4">
                     <span class="w-2 h-2 bg-accent rounded-full"></span>
-                    <span data-version="v{version}">v3.3.0</span>
+                    <span data-version="v{version}">v3.3.1</span>
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl text-chrome mb-4">USER_MANUAL</h1>
                 <p class="text-gray-400 text-lg">Complete guide to installing and using AudioBash on Windows, macOS, and Linux.</p>
@@ -924,7 +924,7 @@ cd audiobash</code></pre>
             <!-- FOOTER -->
             <div class="mt-16 pt-8 border-t border-white/10">
                 <div class="flex flex-col md:flex-row items-center justify-between gap-4 text-gray-500 text-sm">
-                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v3.3.0 - Voice-controlled terminal for Claude Code</div>
+                    <div data-version="AudioBash v{version} - Voice-controlled terminal for Claude Code">AudioBash v3.3.1 - Voice-controlled terminal for Claude Code</div>
                     <div class="flex items-center gap-4">
                         <a href="about.html" class="hover:text-accent transition-colors">About</a>
                         <a href="https://github.com/jamditis/audiobash" class="hover:text-accent transition-colors">GitHub</a>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -158,17 +158,17 @@
         <!-- RELEASES -->
         <div class="space-y-8">
 
-            <!-- v3.3.0 -->
+            <!-- v3.3.1 -->
             <article class="release-card latest bg-panel border border-accent/30 p-6">
                 <div class="flex flex-wrap items-center gap-3 mb-4">
-                    <span class="px-3 py-1 bg-accent text-black font-display font-bold text-sm" data-version="v{version}">v3.3.0</span>
+                    <span class="px-3 py-1 bg-accent text-black font-display font-bold text-sm" data-version="v{version}">v3.3.1</span>
                     <span class="px-3 py-1 bg-accent/20 text-accent text-xs font-mono">LATEST</span>
-                    <span class="text-gray-500 text-sm">June 8, 2026</span>
+                    <span class="text-gray-500 text-sm">June 21, 2026</span>
                 </div>
 
-                <h2 class="font-display text-2xl text-chrome mb-4">Linux builds, hardened transcription, and Wayland shortcuts</h2>
+                <h2 class="font-display text-2xl text-chrome mb-4">Custom dictionary now works on local transcription</h2>
 
-                <p class="text-gray-400 mb-6">AudioBash now ships AppImage and .deb downloads for Linux. Batch cloud transcription requests now run in the main process instead of the renderer. Global shortcuts register under Wayland, not just X11.</p>
+                <p class="text-gray-400 mb-6">The custom dictionary was silently ignored by the local Whisper and Parakeet paths — configured corrections only applied to the cloud providers. Now spoken-to-written entries apply to local model output too, matching the cloud behavior.</p>
 
                 <!-- Downloads -->
                 <div class="bg-void border border-white/10 p-4 mb-6">
@@ -191,6 +191,61 @@
                             Linux (AppImage)
                         </a>
                         <a href="#" data-download="linux-deb" class="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/20 text-chrome text-sm hover:bg-white/10 transition-colors">
+                            <i data-lucide="package" class="w-4 h-4"></i>
+                            Linux (.deb)
+                        </a>
+                    </div>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-6">
+                    <div>
+                        <h4 class="font-display text-signal text-sm mb-2">Fixes</h4>
+                        <ul class="text-gray-400 text-sm space-y-1">
+                            <li>- <strong>Local custom dictionary</strong> - Configured spoken-to-written corrections now apply to local Whisper and Parakeet output, not just cloud providers</li>
+                            <li>- <strong>Consistent behavior</strong> - Local models now match the Gemini, OpenAI, and Anthropic vocabulary-correction behavior</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h4 class="font-display text-accent text-sm mb-2">Quality</h4>
+                        <ul class="text-gray-400 text-sm space-y-1">
+                            <li>- <strong>Regression tests</strong> - New tests assert a configured dictionary entry is applied on both local transcription paths</li>
+                        </ul>
+                    </div>
+                </div>
+            </article>
+
+            <!-- v3.3.0 -->
+            <article class="release-card bg-panel border border-white/10 p-6">
+                <div class="flex flex-wrap items-center gap-3 mb-4">
+                    <span class="px-3 py-1 bg-white/10 text-chrome font-display font-bold text-sm">v3.3.0</span>
+                    <span class="text-gray-500 text-sm">June 8, 2026</span>
+                </div>
+
+                <h2 class="font-display text-2xl text-chrome mb-4">Linux builds, hardened transcription, and Wayland shortcuts</h2>
+
+                <p class="text-gray-400 mb-6">AudioBash now ships AppImage and .deb downloads for Linux. Batch cloud transcription requests now run in the main process instead of the renderer. Global shortcuts register under Wayland, not just X11.</p>
+
+                <!-- Downloads -->
+                <div class="bg-void border border-white/10 p-4 mb-6">
+                    <h4 class="font-display text-chrome text-sm mb-3">Downloads</h4>
+                    <div class="grid sm:grid-cols-3 gap-3">
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.3.0/AudioBash.Setup.3.3.0.exe" class="flex items-center gap-2 px-3 py-2 bg-ice/10 border border-ice/30 text-ice text-sm hover:bg-ice/20 transition-colors">
+                            <i data-lucide="monitor" class="w-4 h-4"></i>
+                            Windows
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.3.0/AudioBash-3.3.0-arm64.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                            <i data-lucide="cpu" class="w-4 h-4"></i>
+                            macOS (Apple Silicon)
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.3.0/AudioBash-3.3.0.dmg" class="flex items-center gap-2 px-3 py-2 bg-apple/10 border border-apple/30 text-apple text-sm hover:bg-apple/20 transition-colors">
+                            <i data-lucide="laptop" class="w-4 h-4"></i>
+                            macOS (Intel)
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.3.0/AudioBash-3.3.0.AppImage" class="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/20 text-chrome text-sm hover:bg-white/10 transition-colors">
+                            <i data-lucide="terminal" class="w-4 h-4"></i>
+                            Linux (AppImage)
+                        </a>
+                        <a href="https://github.com/jamditis/audiobash/releases/download/v3.3.0/AudioBash-3.3.0.deb" class="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/20 text-chrome text-sm hover:bg-white/10 transition-colors">
                             <i data-lucide="package" class="w-4 h-4"></i>
                             Linux (.deb)
                         </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audiobash",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audiobash",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiobash",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Voice-controlled terminal for Claude Code",
   "main": "electron/main.cjs",
   "author": "Joe Amditis",

--- a/tests/unit/docsReleases.test.ts
+++ b/tests/unit/docsReleases.test.ts
@@ -109,14 +109,23 @@ describe('docs do not overstate the transcription hardening', () => {
   // process. Each occurrence must be qualified with "batch" in its immediate lead-in.
   const claimRe = /transcription requests (?:now run|moved) (?:in|into) the main process/g;
 
+  // releases.html and latest.html keep the v3.3.0 entry as frozen release history, so the claim
+  // must stay present (and scoped) there. index.html's single "what's new" panel rotates to the
+  // newest release, so once the homepage moves on (v3.3.1 leads with the local-dictionary fix) the
+  // claim is no longer required there. The anti-overstatement guard below still applies to every
+  // file: any claim that does appear must be scoped to the batch path.
+  const filesRequiringClaim = new Set(['releases.html', 'latest.html']);
+
   for (const name of ['releases.html', 'index.html', 'latest.html']) {
     it(`scopes the main-process transcription claim to batch in ${name}`, () => {
       const html = readFileSync(join(__dirname, '..', '..', 'docs', name), 'utf8').toLowerCase();
       const matches = [...html.matchAll(claimRe)];
-      expect(
-        matches.length,
-        `expected at least one main-process transcription claim in ${name}`,
-      ).toBeGreaterThan(0);
+      if (filesRequiringClaim.has(name)) {
+        expect(
+          matches.length,
+          `expected at least one main-process transcription claim in ${name}`,
+        ).toBeGreaterThan(0);
+      }
       for (const m of matches) {
         const leadIn = html.slice(Math.max(0, m.index - 30), m.index);
         expect(


### PR DESCRIPTION
## Summary

Cuts the v3.3.1 release for the local-model custom dictionary fix that already landed on master via #42. `applyVocabularyCorrections()` previously ran only on the cloud raw-mode paths, so configured spoken-to-written entries were silently ignored by local Parakeet and Whisper. #42 applies the corrections to both local paths; this PR bumps the version and docs to ship it.

### Changes
- Bump version to 3.3.1 (`package.json`, `package-lock.json`, `docs/js/version.js`)
- Update `index.html` / `manual.html` version fallbacks and the build date
- Add the v3.3.1 release card to `releases.html` and `latest.html`; freeze the v3.3.0 entry to a literal version badge and hardcoded v3.3.0 download URLs
- Relax the docs transcription-claim guard: the homepage "what's new" panel rotates to the latest release, so it is no longer forced to carry the v3.3.0 batch-transcription line. The anti-overstatement check still applies to every page (any claim must be scoped to "batch"), and `releases.html` / `latest.html` still require the claim as frozen history.

## Test plan
- [x] `npx vitest run` — 440 passed, 18 skipped, 0 failures
- [x] `npm run electron:build:win` — built `AudioBash Setup 3.3.1.exe` (219 MB); node-pty win32-x64 prebuilds packaged into `app.asar.unpacked`
- [x] Local review passes, no blocking issues
- [ ] Windows installer smoke test: launch, record voice with a local model, confirm a configured dictionary entry is applied